### PR TITLE
chore(installation): add summary frontmatter

### DIFF
--- a/how-to-guides/installation.ipynb
+++ b/how-to-guides/installation.ipynb
@@ -8,6 +8,7 @@
     "date: 2021-08-04\n",
     "downloads: true\n",
     "sidebar: true\n",
+    "summary: Install PyTorch-Ignite from pip, conda, source or use pre-built docker images\n"
     "tags:\n",
     "  - installation\n",
     "  - pip\n",


### PR DESCRIPTION
Summary didn't look good on https://deploy-preview-37--pytorch-ignite.netlify.app/how-to-guides/

---
Hugo summary can be from `summary` frontmatter or the content before `<!--more-->`.
