### PR TITLE
fix: re-save with jupyter lab to bump nbformat

### DIFF
--- a/how-to-guides/01-installation.ipynb
+++ b/how-to-guides/01-installation.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "d13be020",
+   "metadata": {},
    "source": [
     "<!-- ---\n",
     "title: How to install PyTorch-Ignite\n",
@@ -18,11 +20,12 @@
     "  - nightly\n",
     "--- -->\n",
     "# How to install PyTorch-Ignite"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "513c70bb",
+   "metadata": {},
    "source": [
     "From [pip](https://pypi.org/project/pytorch-ignite/):\n",
     "\n",
@@ -41,11 +44,12 @@
     "``` shell\n",
     "pip install git+https://github.com/pytorch/ignite\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "7df69584",
+   "metadata": {},
    "source": [
     "## Nightly releases\n",
     "\n",
@@ -62,11 +66,12 @@
     "``` shell\n",
     "conda install ignite -c pytorch-nightly\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "a0f0118c",
+   "metadata": {},
    "source": [
     "\n",
     "## Docker Images\n",
@@ -99,8 +104,7 @@
     "\n",
     "For more details, [check out our\n",
     "GitHub](https://github.com/pytorch/ignite/tree/master/docker)."
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -119,7 +123,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/how-to-guides/02-convert-pytorch-to-ignite.ipynb
+++ b/how-to-guides/02-convert-pytorch-to-ignite.ipynb
@@ -400,9 +400,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/how-to-guides/03-time-profiling.ipynb
+++ b/how-to-guides/03-time-profiling.ipynb
@@ -955,7 +955,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -969,9 +969,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/how-to-guides/04-fastai-lr-finder.ipynb
+++ b/how-to-guides/04-fastai-lr-finder.ipynb
@@ -2,6 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "id": "5w-QlZE9mvdY"
+   },
    "source": [
     "<!-- ---\n",
     "title: How to use FastaiLRFinder with Ignite\n",
@@ -14,34 +17,38 @@
     "--- -->\n",
     "\n",
     "# How to use FastaiLRFinder with Ignite"
-   ],
-   "metadata": {
-    "id": "5w-QlZE9mvdY"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This how-to guide demonstrates how we can leverage the [`FastaiLRFinder`](https://pytorch.org/ignite/generated/ignite.handlers.lr_finder.FastaiLRFinder.html) handler to find an optimal learning rate to train our model on. We will compare the results produced with and without using the handler for better understanding.\n",
     "\n",
     "<!--more-->\n",
     "\n",
     "In this example, we will be using a [ResNet18](https://pytorch.org/vision/stable/models.html#torchvision.models.resnet18) model on the [MNIST](https://pytorch.org/vision/stable/datasets.html#torchvision.datasets.MNIST) dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Basic Setup"
-   ],
    "metadata": {
     "id": "L_wmAdFgmvdx"
-   }
+   },
+   "source": [
+    "## Basic Setup"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {
+    "id": "lMphyBmmmvdw",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
    "source": [
     "import torch\n",
     "import torch.nn as nn\n",
@@ -53,18 +60,15 @@
     "from ignite.engine import create_supervised_trainer, create_supervised_evaluator\n",
     "from ignite.metrics import Accuracy, Loss\n",
     "from ignite.handlers import FastaiLRFinder"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "lMphyBmmmvdw",
-    "pycharm": {
-     "is_executing": false
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
+   "metadata": {
+    "id": "eZeKOgKymvdx"
+   },
+   "outputs": [],
    "source": [
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
@@ -102,51 +106,48 @@
     "model = Net().to(device)\n",
     "optimizer = torch.optim.RMSprop(model.parameters(), lr=1e-06)\n",
     "criterion = nn.CrossEntropyLoss()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "eZeKOgKymvdx"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "We will first train the model with a fixed learning rate (lr) of 1e-06 and inspect our results. Let's save the initial state of the model and the optimizer to restore them later for comparision."
-   ],
    "metadata": {
     "id": "b04erc67G8IK"
-   }
+   },
+   "source": [
+    "We will first train the model with a fixed learning rate (lr) of 1e-06 and inspect our results. Let's save the initial state of the model and the optimizer to restore them later for comparision."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
+   "metadata": {
+    "id": "HglaeKrqFlkY"
+   },
+   "outputs": [],
    "source": [
     "init_model_state = model.state_dict()\n",
     "init_opt_state = optimizer.state_dict()"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "HglaeKrqFlkY"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Without LR Finder"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "source": [
-    "trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
-    "\n",
-    "trainer.run(train_loader, max_epochs=3)"
-   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "dKihuuH4A-sH",
+    "outputId": "699eebb6-7446-40cd-9b91-ebdaea07eaeb"
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
@@ -162,23 +163,38 @@
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 24,
      "metadata": {
       "tags": []
      },
-     "execution_count": 24
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "dKihuuH4A-sH",
-    "outputId": "699eebb6-7446-40cd-9b91-ebdaea07eaeb"
-   }
+   "source": [
+    "trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
+    "\n",
+    "trainer.run(train_loader, max_epochs=3)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "mophHZUkICKI",
+    "outputId": "378c7aac-b3c8-49ff-8be1-acc547730c12"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Accuracy': 0.8655, 'Loss': 0.602867822265625}\n"
+     ]
+    }
+   ],
    "source": [
     "evaluator = create_supervised_evaluator(\n",
     "    model, metrics={\"Accuracy\": Accuracy(), \"Loss\": Loss(criterion)}, device=device\n",
@@ -186,64 +202,52 @@
     "evaluator.run(test_loader)\n",
     "\n",
     "print(evaluator.state.metrics)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "{'Accuracy': 0.8655, 'Loss': 0.602867822265625}\n"
-     ]
-    }
-   ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "mophHZUkICKI",
-    "outputId": "378c7aac-b3c8-49ff-8be1-acc547730c12"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's see how we can achieve better results by using the [`FastaiLRFinder`](https://pytorch.org/ignite/generated/ignite.handlers.lr_finder.FastaiLRFinder.html) handler. But first, let's restore the initial state of the model and optimizer so we can re-train them from scratch. "
-   ],
    "metadata": {
     "id": "U_EHmN2bmvd2"
-   }
+   },
+   "source": [
+    "Let's see how we can achieve better results by using the [`FastaiLRFinder`](https://pytorch.org/ignite/generated/ignite.handlers.lr_finder.FastaiLRFinder.html) handler. But first, let's restore the initial state of the model and optimizer so we can re-train them from scratch. "
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
+   "metadata": {
+    "id": "CTGJPVI6mvd2"
+   },
+   "outputs": [],
    "source": [
     "model.load_state_dict(init_model_state)\n",
     "optimizer.load_state_dict(init_opt_state)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "CTGJPVI6mvd2"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## With LR Finder"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "When attached to the `trainer`, this handler follows the same procedure used by [fastai](https://docs.fast.ai/callback.schedule.html#LRFinder). The model is trained for `num_iter` iterations while the learning rate is increased from `start_lr` (defaults to initial value specified by the optimizer, here 1e-06) to the upper bound called `end_lr`. This increase can be linear (`step_mode=\"linear\"`) or exponential (`step_mode=\"exp\"`). The default `step_mode` is exponential which is recommended for larger learning rate ranges while linear provides good results for small ranges."
-   ],
    "metadata": {
     "id": "fLaAAE05GIFh"
-   }
+   },
+   "source": [
+    "When attached to the `trainer`, this handler follows the same procedure used by [fastai](https://docs.fast.ai/callback.schedule.html#LRFinder). The model is trained for `num_iter` iterations while the learning rate is increased from `start_lr` (defaults to initial value specified by the optimizer, here 1e-06) to the upper bound called `end_lr`. This increase can be linear (`step_mode=\"linear\"`) or exponential (`step_mode=\"exp\"`). The default `step_mode` is exponential which is recommended for larger learning rate ranges while linear provides good results for small ranges."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 27,
+   "metadata": {
+    "id": "qEA0T0af3iU1"
+   },
+   "outputs": [],
    "source": [
     "lr_finder = FastaiLRFinder()\n",
     "\n",
@@ -252,32 +256,30 @@
     "\n",
     "with lr_finder.attach(trainer, to_save, end_lr=1e-02) as trainer_with_lr_finder:\n",
     "    trainer_with_lr_finder.run(train_loader)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "id": "qEA0T0af3iU1"
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's plot how the learning rate changes within our specified range and print the suggested learning rate."
-   ],
    "metadata": {
     "id": "lzhRX59cRDXO"
-   }
+   },
+   "source": [
+    "Let's plot how the learning rate changes within our specified range and print the suggested learning rate."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 28,
-   "source": [
-    "lr_finder.plot()\n",
-    "\n",
-    "print(\"Suggested LR\", lr_finder.lr_suggestion())"
-   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 300
+    },
+    "id": "oN0VkPapmvd5",
+    "outputId": "b2f3fc64-046e-43a4-cd7a-e604003b8c6f"
+   },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd3zU9f3A8dfnsncIWZAACRBGCBsDsgQnikKtoqJYRxVnbW1rqz8VR21rp1ZLnbXiKuJGRXFBlSUEZIMQwkiYCWTv3L1/f9wlJpBxCTcy3s/HI4/kvuve901y7/tsIyIopZTquizeDkAppZR3aSJQSqkuThOBUkp1cZoIlFKqi9NEoJRSXZwmAqWU6uJ8vR1Aa0VHR0tSUpK3w1BKqQ5l/fr1eSIS09i+DpcIkpKSyMjI8HYYSinVoRhj9je1T6uGlFKqi9NEoJRSXZwmAqWU6uLc2kZgjJkG/APwAV4UkcdP2t8bWABEOo65V0SWtPZ5qqurycnJoaKiwgVRK9U5BAYGkpiYiJ+fn7dDUe2c2xKBMcYHmA+cB+QA64wxi0Vke73DHgAWicgzxphUYAmQ1NrnysnJISwsjKSkJIwxLoheqY5NRDh+/Dg5OTkkJyd7OxzVzrmzaigdyBSRLBGpAhYCM086RoBwx88RwKG2PFFFRQXdu3fXJKCUgzGG7t27aylZOcWdiSAByK73OMexrb6HgTnGmBzspYGfNXYhY8xcY0yGMSYjNze30SfTJKBUQ/o/0T4cLapgb16pt8Nolrcbi2cDL4tIInAR8Kox5pSYROR5ERkjImNiYhodD9E6IrBmDbz3nv27rsmglHKxdftO8Pq3+xn7hy+5+KlvKKuq8XZITXJnIjgI9Kr3ONGxrb6fAosARGQ1EAhEuzEmWLIEeveG886D66+3f+/d2769k9i4cSNL2vB6pkyZ0uhgvaa2n2znzp2MGDGCkSNHsmfPnlY/v2qdP/7xj/Tv35+BAweydOlSb4ej6rHahFnPrub+97YCUFplZem2I16OqmnuTATrgBRjTLIxxh+4Clh80jEHgHMAjDGDsSeCxut+XGHJErj8csjJgZISKCqyf8/JsW/vJMmgrYmgtaxWa4PH77//Ppdffjnfffcd/fr1a/F8EcFms7ksnpoa733i8vRzb9++nYULF7Jt2zY+/fRTbr/99lN+H8p7snJL6n5edMuZJEQG8fHmLpgIRKQGuBNYCuzA3jtomzHmUWPMDMdhvwJuNsZsAv4LXC/uWjtTBObOhfLyxveXl8Mtt7Spmqi0tJTp06czfPhw0tLSePPNNwH7dBh5eXkAZGRkMGXKFAByc3M577zzGDJkCDfddBN9+vSpO+53v/sdAwcOZOLEicyePZu//vWvAOzZs4dp06YxevRoJk2axM6dOwF46623SEtLY/jw4UyePJmqqirmzZvHm2++yYgRI3jzzTcpLS3lxhtvJD09nZEjR/LBBx84XnI5V111FYMHD+bSSy+lvKl7U09oaCi/+tWvGD58OKtXr67bvmTJEp588kmeeeYZpk6dCsDf//530tLSSEtL48knnwRg3759DBw4kJ/85CekpaWRnZ3d4PpJSUn85je/YejQoaSnp5OZmQnAhx9+yNixYxk5ciTnnnsuR48eBeDhhx/m2muvZcKECVx77bXs27ePSZMmMWrUKEaNGsWqVasAWL58OWeddRYzZ86kb9++3Hvvvbz++uukp6czdOjQZkswe/bsYdy4cQwdOpQHHniA0NDQumtOmjSJGTNmkJqaSkVFBTfccANDhw5l5MiRLFu2DICXX36ZO++8s+56F198McuXL6+7n3fffTdDhgzhnHPOobYN7KmnniI1NZVhw4Zx1VVXnRLTBx98wFVXXUVAQADJycn079+ftWvXtvj7U56x9VAhAEt/MZn05CjSk6PYerDQy1E1Q0Q61Nfo0aPlZNu3bz9l2ylWrxYJDRWxv9U3/hUaKrJmTcvXOsnbb78tN910U93jgoICERHp06eP5ObmiojIunXr5KyzzhIRkTvuuEP+8Ic/iIjIJ598IoDk5ubK2rVrZfjw4VJeXi5FRUXSv39/+ctf/iIiImeffbbs2rVLRETWrFkjU6dOFRGRtLQ0ycnJERGR/Px8ERH5z3/+I3fccUddPPfdd5+8+uqrdcekpKRISUmJ/O1vf5MbbrhBREQ2bdokPj4+sm7dulNe31lnnVW3HZA333yz0fvw0EMP1cWbkZEhaWlpUlJSIsXFxZKamiobNmyQvXv3ijFGVq9e3eg1+vTpI4899piIiCxYsECmT58uIiInTpwQm80mIiIvvPCC/PKXv6x7zlGjRklZWZmIiJSWlkp5ebmIiOzatUtq/16WLVsmERERcujQIamoqJCePXvKvHnzRETkySeflJ///OeNxiMiMn36dHnjjTdEROSZZ56RkJCQumsGBwdLVlaWiIj89a9/rbufO3bskF69ekl5efkpv4/p06fLsmXL6u7na6+9JiIijzzySN1xPXr0kIqKChH54fda3x133FH3OxURufHGG+Wtt9465Tin/jeUyz2yeJsMfGCJVNdYRUTkha/3SJ/ffiR5xRVeiwnIkCbeV73dWOw5hw+DpYWXa7HAodb3YB06dCiff/45v/3tb/nmm2+IiIho9vgVK1bUfcqbNm0a3bp1A2DlypXMnDmTwMBAwsLCuOSSSwAoKSlh1apVzJo1ixEjRnDLLbdw+PBhACZMmMD111/PCy+80GTVwGeffcbjjz/OiBEjmDJlChUVFRw4cICvv/6aOXPmADBs2DCGDRvW4mv18fHhsssua/G4FStWcOmllxISEkJoaCg//vGP+eabbwDo06cP48aNa/Lc2bNn132vLXXk5ORwwQUXMHToUP7yl7+wbdu2uuNnzJhBUFAQYB9cePPNNzN06FBmzZrF9u0/DFs544wz6NGjBwEBAfTr14/zzz8fsP/+9u3b12Q8q1evZtasWQBcffXVDfalp6fX9dNfsWJF3f0cNGgQffr0YdeuXc3eJ4vFwpVXXgnAnDlzWLFiBWD/fVxzzTW89tpr+Pp2uLkhu7yN2fmk9YzA18f+npPaw95LftuhIm+G1aSukwh69ICW6qNtNujZs9WXHjBgABs2bKirOnj00UcB8PX1rasDP53+3DabjcjISDZu3Fj3tWPHDgCeffZZHnvsMbKzsxk9ejTHjx8/5XwR4Z133qk798CBAwwePLhNsQQGBuLj49Pm1wIQEhLS7P763R5rf/7Zz37GnXfeyZYtW3juueca3M/613viiSeIi4tj06ZNZGRkUFVVVbcvICCg7meLxVL32GKxtLmOv6XXAg3/DqD5v4Xa1/vxxx9zxx13sGHDBs4444xT4ktISGhQrZaTk0NCwsm9s5U3lFdZ2ZxTyJikqLptQ3pGYAx8seOoFyNrWtdJBGPHQguf1ImMhPT0Vl/60KFDBAcHM2fOHO655x42bNgA2Ou7169fD8A777xTd/yECRNYtGgRYP+0np+fX7f9ww8/pKKigpKSEj766CMAwsPDSU5O5q233gLsb+ybNm0C7PXXY8eO5dFHHyUmJobs7GzCwsIoLi6ue74LLriAp59+GnG0f3z33XcATJ48mTfeeAOArVu3snnz5la/9qZMmjSJ999/n7KyMkpLS3nvvfeYNGmSU+fWtrG8+eabnHnmmQAUFhbWvdEtWLCgyXMLCwvp0aMHFouFV1991SUNqOPGjav7/S1cuLDJ4yZNmsTrr78OwK5duzhw4AADBw4kKSmJjRs3YrPZyM7OblCXb7PZePvttwF44403mDhxYt1xU6dO5U9/+hOFhYWUlJQ0eK4ZM2awcOFCKisr2bt3L7t37ya9DX+7yvW+y86nxiakJ3er2xYR7Mc1Y3vzyur97Dpa3MzZ3tF1EoEx8Pzz4KhCOEVQEDz3nP24VtqyZQvp6emMGDGCRx55hAceeACAhx56iJ///OeMGTOmwafohx56iM8++4y0tDTeeust4uPjCQsL44wzzmDGjBkMGzaMCy+8kKFDh9ZVM73++uv8+9//Zvjw4QwZMqSuwfeee+5h6NChpKWlMX78eIYPH87UqVPZvn17XWPxgw8+SHV1NcOGDWPIkCE8+OCDANx2222UlJQwePBg5s2bx+jRo1v92psyatQorr/+etLT0xk7diw33XQTI0eOdOrc/Px8hg0bxj/+8Q+eeOIJwN4oPGvWLEaPHk10dNM9jG+//XYWLFjA8OHD2blzp1Of2Fvy5JNP8ve//51hw4aRmZnZZNXf7bffjs1mY+jQoVx55ZW8/PLLBAQEMGHCBJKTk0lNTeWuu+5i1KhRdeeEhISwdu1a0tLS+Oqrr5g3bx5Wq5U5c+bUNTrfddddREZGNniuIUOGcMUVV5Camsq0adOYP3/+aZfUlGtsO2iv/hnZq1uD7deM7QPA7qMlp5zjdU01HrTXrzY3Ftf6+GORxER7w3B4uP17YqJ9u4dUVFRIdXW1iIisWrVKhg8fXrevuLhYROyNnqNHj5b169d7LK72oH4De3tRWlpa11D93//+V2bMmOGya9c2PLuLNhZ73tNf7pI+v/1IqhwNxbVyiyukz28/kpdX7vVKXDTTWNz1WqEuuggOHIC1a+0Nwz172quDPDgc/8CBA1xxxRXYbDb8/f154YUX6vbNnTuX7du3U1FRwXXXXdfg06PyjvXr13PnnXciIkRGRvLSSy95OyTVjlkdzUGWk95TugX7YzGQW1zphaia1/USAdjf9MeO9drTp6Sk1NXTn6y2zr6raq73jrv9/ve/r2uHqTVr1izuv//+ujYZVzu57l91fFZHW5zlpM+WPhZD99AA8ko0EbiNiOgkW+q03H///dx///3eDsNlROfQ8gr7e1Hjk/5Ft9NE0CkaiwMDAzl+/Lj+4SvlII71CAIDA70dSpdjtQk+TXwojQ7116ohd0lMTCQnJ4empqhWqiuqXaFMeZZVBMvJ9UIOMWEBZOW2vympO0Ui8PPz01WYlFLtgsip7QO1YkIDyC2pbHdV2Z2iakgppdqL5quGAqiqsVFU0b7WJtBEoJRSLmRroWoIaHcNxpoIlFLKhWw2OWUMQa3oUHsiaG8NxpoIlFLKhawi+DRRIogO8we0RKCUUp2arYXGYoA8LREopVTn1VzVULdgf3wshlwtESilVOdla6ZqyGIxRIX4k1dc1eh+b9FEoJRSLmS1nTrhXH0x7XCaCU0ESinlQvbuo03vjw4L4Ji2ESilVOdlk6YHlAEkRAaRk1/mwYhapolAKaVcyNpMYzFAUvdg8suqKSyr9mBUzdNEoJRSLtTcyGKAPt3ty6fuP9F+Jp/TRKCUUi5ks9Fs1VBytD0R7DvefqqH3JoIjDHTjDHfG2MyjTH3NrL/CWPMRsfXLmNMgTvjUUopd7M6FqZpSu+oYAD257WfEoHbpqE2xvgA84HzgBxgnTFmsYhsrz1GRO6ud/zPgJHuikcppTxBmhlHABDk70OvqCA25RR6MKrmubNEkA5kikiWiFQBC4GZzRw/G/ivG+NRSim3a6mxGOCcQXF8szuX0sr2MR21OxNBApBd73GOY9spjDF9gGTgqyb2zzXGZBhjMnQVMqVUe2YVmm0sBpiWFk9ljY35yzLbxRK77aWx+CrgbRGxNrZTRJ4XkTEiMiYmJsbDoSmllPNEBJ8WFh9LT4rix6MS+NfyPTz60fbmD/YAdyaCg0Cveo8THdsacxVaLaSU6gScqRqyWAx/mzWcH49KYMGqfZRXNfoZ2GPcmQjWASnGmGRjjD/2N/vFJx9kjBkEdANWuzEWpZTyCKut+XEEtYwxTBsSj01g++EiD0TWNLclAhGpAe4ElgI7gEUiss0Y86gxZka9Q68CFkp7qChTSqnTJNL8OIL6hiVGArAlx7s9593WfRRARJYAS07aNu+kxw+7MwallPIkqwh+TpQIAOLCA4gODWDzQe92JW0vjcVKKdUp2KTlNoJaxhiGJUawVROBUkp1HjZb8wPKTjY0IYLMYyWUVXlvTIEmAqWUciFrK0oEYE8ENoHth7zXYKyJQCmlXMjWwgplJxuWGAHAun357gqpRZoIlFLKhextBM4fHxseSHpyFP9ekUWJl6ac0ESglFIu1Nzi9U35zQUDySupYsnmw26KqnmaCJRSyoWcHVBW3+g+3UiIDOKz7UfdFFXzNBEopZQL2aR1bQRg70Z6Xqp9RtLKGs9PN6GJQCmlXMjmxKRzjUntEU5ljY1jRZWuD6oFmgiUUsqF2lI1BBAXEQjAkaIKV4fUIk0ESinlQjYnZh9tTHy4IxEUaiJQSqkOzdaKSefqq00ER7VEoJRSHZtV2lY1FB7kS6CfRUsESinV0UkrB5TVMsYQFx7I0WJtLFZKqQ7N2spJ5+qLCw/kqJYIlFKqY3NmqcqmxIcHaq8hpZTq6KQNA8pqxUfYE4GnF2zURKCUUi5kFcGnje+sceGBVNXYKCirdm1QLdBEoJRSLnQ6VUNx4QGA5weVaSJQSikXEqFN3UfBe2MJNBEopZQLWUXaNKAM7FVDoIlAKaU6tNYuTFNfXN00E54dS6CJQCmlXERETqtqyN/XQnSoP4cLy10cWfM0ESillItYbfZun21tLAZI6h5CVm6pq0JyilsTgTFmmjHme2NMpjHm3iaOucIYs90Ys80Y84Y741FKqZN9vSuXT7e6ZolIRx5o88higP6xoWTmlrgkHme5LREYY3yA+cCFQCow2xiTetIxKcB9wAQRGQL8wl3xAJRXeX7lH6VU+/av5Zk8+uF2l1zLJqdfIugfG8qJ0ipOlFa5JCZnuLNEkA5kikiWiFQBC4GZJx1zMzBfRPIBROSYq4MQEX7z9iaGPryUwfM+5dU1+139FEqpDqygrJpDhRUcc0FPnR8SQduv0S82FICnv9rtsRHG7kwECUB2vcc5jm31DQAGGGNWGmPWGGOmNXYhY8xcY0yGMSYjNzfXqSfPPFZC5rESXvgmi0UZORRX1ADwyOJtfLLlMBc//Q0PvL/FK+uDKqXaj9pRvN9lF5z2tWrbCE6naii1RzgA/1m5j805hacdkzN8PfIszT9/CjAFSAS+NsYMFZEGvxEReR54HmDMmDEtpsgaq42Z/1xBqaMq6KKh8Zw7OI7yait/+HgHt72+AYCtB4uIDg3gF+cOcOVrUkp1IAXl9iqYjdkFXDAk/rSuZbPZv59O1VBceCDv3Daey55ZxYYD+QzvFXlaMTnDnYngINCr3uNEx7b6coBvRaQa2GuM2YU9Maxr7sLlVVaC/H2a3P/FjqOUVlmJCQvgslGJ/Ozs/oQE2F/q5JQYNuUUML5fNA++v5Vn/7eHCf2jOSMpqvWvUCnVoVVUW6motr97b3JBicAVVUMAo/t0Iz48kI0uiMkZ7qwaWgekGGOSjTH+wFXA4pOOeR97aQBjTDT2qqKs5i6aX1rFkIc+5d0NOZworeLllXvJPFaCzfZDQeHVNftJiAxizX3ncO+Fg+qSAECvqGAuHtaTqBB/HpqRSs+IIK57aS3r9+e74jUrpTqQ2mqhID8fNucU1lXttJVVTr9qqNbI3pGs35/vkXYCt5UIRKTGGHMnsBTwAV4SkW3GmEeBDBFZ7Nh3vjFmO2AF7hGR481dN6egnB4Cv1y0CWPs83oA+FoMKXFhHDheSmmVlXsuGNjiLyM2LJCFc8cxc/5K/vbZ97xx87jTft1KqY6jtlpofL/ufLnzGHtySxgQF9bm69V+IG3rgLL6pg6M5ZOtR8jYn+/2Ggu3jiMQkSUiMkBE+onI7x3b5jmSAGL3SxFJFZGhIrKwpWtGhfgzY3hP/HwM149P4sWfjGF2em+uH59ETFgAE1OiGd+vO7PTezsVY2x4IDNHJLB27wkKy+2fDmqsNo/PB66U8rz8Uvv//FkDYwDYcpqNs7UFitNpI6h18fAehAX68upq9/d09HZjcaslRAbx1OyRVFuH4+eY9Pvc1LjTuuZ5qbE8+789PPj+VgbGh/Hs8j3cclZf7jw7xRUhK6XaqUJHiWBEr0j8fAy7j53eQK66qiEXJIJgf18uG5XI69/uJ68klejQgNO+ZlM67BQTfm1d+aERI3t146cTk/lk62H+svR7iitr+OeyTAo9vDiEUsqz8h3/49GhASR1DyHzNBNBbdWQC/IAAHPG9aHaKrz/3cn9bFyrwyYCV7JYDA9enMqWhy/guwfP46OfTaTaKvz4mZVUVOs4A6U6q9rG4shgP/rHhrLnNKd2sLmwsRjso4zjwwPZfrjIJddriiaCegL9fOgW4k9aQgT/nD2SPbmlfL79qLfDUkq5SWF5NX4+hiA/H1JiQ9l/vPS0Pvy5YkDZyfrFhrDHzZPQaSJowgVD4ukREciijGxtOFaqkyquqCYs0A9jDP1iQ7EJ7Dve9jfd2sZi46q6IaBfTChZx0rc+j6kiaAJFou9V9I3u/P489LvdSoKpTqh4ooawgPtfWZSYu3dRk+nncDmwsbiWv1jQymurCG32H2L1WgiaMbNk/py2ahEnlm+h5++nKHJQKlOprZEANA3JgRjYPfRtieCH6qGXBIeYC8RAG6dmloTQTMsFsPfrhjO4z8eyorMPBauzW75JKVUh1FcUUOYo0QQ6OdD76jg03rDrS0RuLJqqHdUMAA5J9y3apkmAidceUYv0pOi+NfyzAYNSYsysln2vctnzlZKeUj9RADQPyaUPadTNeSYdM6VVUPxEYFYDOTkl7nsmifrcAPKvMEYwy/OS+HqF77lsY+3syWnkMSoYD7ebF/V6JUb05k8IKbueBFx6ScCpZR7FNWrGgJ7ffw3u/OosdrwbUP9jqu7j4J9zFR8eCA5Be4rEWgicNL4ftFM7B/Na2sOALApp5C+MSEUlVdzxxsbuH1Kf5K6B5NXWsU/vtjF4z8edtojnpVS7nVKiSA2lCqrjez8cpKjQ1p9Pau4dkBZrcRuweTkayJoF56ZM4o/fbqTC4bEM6ZPFP6+Fp77eg9//vR7/vTpzgbH3vrael75aTrj+0V7KVqlVHOsNqGksuaUEgHYew61JRHY3DCOACChWxBr955w6TXr00TQCmGBfjz2o6ENtt0wPpluwf6cPSiWXUeLWbBqP7dP7cev39rE1S98y9zJfbn73AHNrp+glPK8kkr7qoXhJ5UIAHYfK+a8NpToXTnpXH2J3YL4YGM51VabS6fXqaWNxacpyN+H2em9iQsPZFJKDC9eN4ZRvbvxfxcOBuD5r7P4bPuRBufUWG18ueMoizKytUuqUl5SXGGfXqJ+1VBYoB/x4YFt7kJaVWNvLfZ1cYmgd1QwNsFt1UNaInCTcwbH8sSVw7n7zU088P5Wqq3CoYJyjpdUsnxXLvuP23sAfJt1gr9dMdzL0SrV9dSuYx5er2oI7DORrt17ok2dPmp79vSMDHJNkA59HWMJsnLbVmXVEi0RuIkxhktHJnJ+ahzFFTX8+q1NPPHFLv67NpuSihqeuWYUcyf35Z0NOazYneftcJXqcorKa0sEDRPBpAHRHCwoZ+G61k8vs/9EGX4+xvWJwPHmn+WmOYe0ROBm9144iPTkKGLCAhgYH0ZydAgWY/DzsXD24FiWbDnMHz/ZwYf9JrpkVSOllHPKHGOCggMatt9NTrF3Bb/v3S0E+/swc0SC09fcf7yUXt2CXd5Y3C3En27BfmTluWd0sZYI3KxvTCg3TerLzBEJDIoPJ8DXp66xJ8DXh3suGMi2Q0Vc+swqXlm9r67XQX5plRejVqrzq63P9z+p8bVXVDDPzhkNwD+/ymxVqWBfXhm9uwe7Lsh6+saEum0WUk0EXnbJsJ5cPbY3BWVVzPtgG498uI0lWw4z6rHPWZmpVUZKuUulIxEE+p36NjgtLZ5HZw5h97ESpxtoRYQDJ8pI6u76OnyAgfFh7DhUVDefkStpIvAyi8Xwh0uHsvzXU/jpxGQWrN7P7a9vQAR+//EOSh1d3JRSrvVDiaDxrt0jekUCsNnJdYyLKmooqawhwcXtA7XOSOpGcWUNO4+4fpEapxKBMSbEGGNx/DzAGDPDGOPX0nnKecbYV0mbf/UozhoQwy1n9WXnkSJuWpBRV12klHKd2q7bAY2UCAAGxYfj72Nhc06BU9fLK7FPEx0T5p61hcf0iQIgY1++y6/tbGPx18AkY0w34DNgHXAlcI3LI+ripg/rwfRhPQBI7h7Cve9u4dGPtnP/9MFuGUiiVFfVVBtBLX9fC4N7hDldIshzrBfQPdTfNQGeJLFbELFhAWzKdi4xtYaz7yxGRMqAHwP/EpFZwBCXR6MauPKMXswZ15uXV+3j6S93ezscpTqVukTg2/TbYEpcmNM9dfJK7B08okPdUyIwxtA/NpSsPNc3GDudCIwxZ2IvAXzs2KZzJriZMYbHfjSUmSN68uzXWXx3IJ+jRRXUWG3eDk2pDq+2sTigmUTQOyqYo0WVTq1jfLzUXiJwVyIASI4OYa8XE8EvgPuA90RkmzGmL7CspZOMMdOMMd8bYzKNMfc2sv96Y0yuMWaj4+um1oXfNcy7OJX48EBufHkdEx7/iqtf+FYbkZU6TVU1NiyGZqeb7uPoCnrgRMtrAeQVV2IxEBXinqohsCeCwvJql3cvdyoRiMj/RGSGiPzJ0WicJyJ3NXeOMcYHmA9cCKQCs40xqY0c+qaIjHB8vdjaF9AVdA8N4MXrxlBebaXGJqzdd4LfL9nh7bCU6tCqrLZmq4Xgh9XBaqeEaU5uSRVRIf4uH0xWX+30Eq6uHnK219AbxphwY0wIsBXYboy5p4XT0oFMEckSkSpgITDz9MLtugbEhfH2reP55jdTmTu5L298e4CntN1AqTarrLYS4Nt8DXcfx5gAp0oEJZV0D3FftRBAkiMR7PNGIgBSRaQI+BHwCZAMXNvCOQlA/UV+cxzbTnaZMWazMeZtY0yvxi5kjJlrjMkwxmTk5uY6GXLnk5YQQa+oYH47bRAXDInj+a+znKq7VEqdypkSQbdgP0IDfDlwvOU33rySSqLD3FctBNRNX+HqdgJnE4GfY9zAj4DFIlINuKJz+4dAkogMAz4HFjR2kIg8LyJjRGRMTExMY4d0KT4Ww9xm5XsAACAASURBVDVj+1BSWcNyXTNZqTaprLE121AM9g4bvaOC2e9EieBYUSVxYYGuCq9R/r4WenULYq8Tiak1nE0EzwH7gBDga2NMH6Cl4W0Hgfqf8BMd2+qIyHERqXQ8fBEY7WQ8Xd6Z/boTHx7IXQs38uI3WW7pSaBUZ1ZZ03KJAOwNxgdaaCOw2oQjRRX0iHRvIgB79dBeF8855Gxj8VMikiAiF4ndfmBqC6etA1KMMcnGGH/gKmBx/QOMMT3qPZwBaAuok/x8LLx7+3hSe4Tz2Mc7uOgf35B5rITvjxRTY7Vx+TOr+NH8lSzKyOZYcYW3w1Wq3amqsTU5mKy+3lH29YKbm+Mnr6QSq02Ij3DP9BL1JUeHsO94aaunyG6OUyOLjTERwEPAZMem/wGPAk0OuRORGmPMncBS7GMOXnJ0PX0UyBCRxcBdxpgZQA1wAri+rS+kK+oZGcSCG9J5dc0+nv4qk5n/XEFpVcM2g43ZBYQG+PL6TWMZ7pg7RSllTwQBfi0Ph+rdPZgqq40jRRVNziN0qMA+MV3PCPeXCJKjQyirsnKsuJK4cOeeb+vB5kdHO1s19BJQDFzh+CoC/tPSSSKyREQGiEg/Efm9Y9s8RxJARO4TkSEiMlxEporIzuavqE4WEezHnWensHDuOIIDfOnu6MOcHB1C5u8vZNEtZ9ItxI+fLsjgSKGWDJSqVVljJcCJEkGfKHtPnf3N1MvX/m/FeygRQOsWqbnl1fXN7nd2rqF+InJZvcePGGM2Oh2FcruRvbux9v/OwRhTN/mVr4+F9OQoXrruDGbOX8kvF23kxevGEOyv6xEpVVVjIySg5f+FXlH2UkDOiXLo1/gxhxyJoKeHqoYA9h0v5cx+3Z06p6Cs+QFozpYIyo0xE2sfGGMmAO5ZRVm1We36qtGhAQ2GuafEhXHXOSms2nOc8Y9/pSUDpXB0H3WiRFBb/XKkqOn/myOF5QT6WYgMdv+kzD0jgvD3tTjdQaSqxnZKlfHJnP1oeCvwiqOtACAfuM7Jc1U7cPOkvkQE+XH/e1uY9exKfh1ewMWx4JOQAGPHQisX6Vaqo6usdq7XUKCfD1Eh/hxu5gPUocIKekQEtXqx+7awWAxJ3YOdTgSFjrWZm+NUIhCRTcBwY0y443GRMeYXwGanIlFe52MxzE7vTa/Vyxnw0K8JLivG6u+LjwEiI+G55+Cii7wdplIeU2VteRxBrfjwQI42UyI4XFBODw+0D9RKjg5xetnKwvKW5yVq1QT3IlLkGGEM8MvWnKvagSVLmHjfrcQW5hJaXYF/aQmUlEBODlx+OSxZ4u0IlfIYZ0sEAD0iApstERwprPBIQ3GtlNgw9uWVUuLE5JP5ZS2XCE5npROtS+hIRGDuXChvommnvBxuucV+nFJdgL1E4Nxs+vERgRwpbPx/x2oTjhZXeqShuNb4ft2psQnfZh1v8dgCNycCfcfoSL79FgpbWGmpoADWrvVMPEp5WZWTI4vBXjWUX1bd6NxeucW1g8k8VyIY1acbgX4Wvt7V8txrLfUYghYSgTGm2BhT1MhXMdDT6aiV9x0+DJbm/+jFYoFDhzwUkFLeVVljdToRJHSzf9pvbDrqQ46SQk8PTC9RK9DPh3MHx/HftdktrqnsTGNxs3dBRMJEJLyRrzAR0c7oHUmPHmBrfmWzispqqmLjPBSQUt5jswnVVnG6sXhU724ArN134pR9hwscg8nCPVc1BPDYj9Lw9TG8u+Fgs8cVlFW3uEaCrobeVYwdCxERzR6S7x/CM2XRHgpIKe+psra8XnF9fboHExce0Gid/PdHirCYHwZ6eUpksD8pcWHsOlrc7HH5ZVVEBjU/vkETQVdhDDz/PAQ1/qlFgoL44NZ5zF++h8xjzi3WrVRHVduAGhbo3AAwYwxjk7uzdu+pJYItBwtJiQ0jyN/zy7gPiA1ldwv/r3kllXRrYflMTQRdyUUXwdtvQ2IihIZCeLj9e2Ii5u23ufzBuQT6Wfi/d7dga2amRaU6utp5g2qXonTGiF6RHCuubDCeQETYcrCQtITmS9vukhIXSm5xZbMNwpnHSujbQmlFE0FXc9FFcOAAfPEFvPyy/fuBA3DRRcSEBXD/9MGs3XeCm1/J4IONzdc9KtVR1S492acViWBYov3NfkvOD73vjhZVkldSxdCEcNcG6KSU2DCAJksFlTVW9h0vY0BcWLPX0QbfrsgYe5tBI64Y04tDBRX848vdfPX9Mcb3iyYmzL3rsCrlaQdOlOFjMXW9gZyR2jMci4HNBws5N9XeqaK2ZNEvNtQtcbYkJc7+vLuOFnNGUtQp+/fmlWK1Sd1xTdESgWrAGMPd5w3g87snIwKPf7KT977LobJG10ZWncf+42X0jAzEz4lJ52oF+/syuEc4b2Vkc9Cx/kBOvv17YjfnSxau1DMiiGB/H3YfbbxEsMuxvaUSgSYC1aiUuDDSk6J4Z0MOd7+5iTte/46qmua7nyrVUew/UVa3zkBr/OmyYRwvqWLBqn3AD4nAk2MI6rNYDCmxoew+1njPoYOO+Pp0bz5RaSJQTXr95rGsu/9cHr4klS92HOWnC9bx8ebDjY6uVKojKS6vbtOU0WkJEQzvFVHXeygnv4y48ACnp6pwh/6xYU2WCArLq/H3sRDUwkpsmghUk/x8LMSEBXD9hGR+N3MIKzLzuOONDdz7zmaXrpeqlKc5u3B9Y85IimLrwULKqmrIyS/3WrVQrUHxYRwrrqxbLrO+wvIqIoL9WpweWxOBcsq1Zyax5K5JTB/Wg/c3HuLGl9fxzvocaqxaXaQ6ntZMQX2ycX3tE76lzlvK6qzjJLaiwdkdzh9ib7helJF9yr6CsuoWB5OB9hpSrTC4RzhPXzWSpO7BvLbmAMu+z+VQQTk/OyfF26Ep1SpVNc6tTtaYif2jmZQSzTe78xjVO5LLRye6OLrW6dM9hLHJUTz5xW5sNuGX5w+s21dQ5lwVmJYIVKtYLIZ7LhjExnnnMbF/NAvXZevgM9XhtGbm0ZNZLIbnrx3DRz+byLu3T2BSSoyLo2u9p2aP5OxBsTy9LLPBJHQF5dVEOFEi0ESg2sQYwxVn9OJgQTlPfbWb/NKWp7pVqr2osrY9EQAE+ft4bTRxY+LCA3nyqhEALNv5w9TUReXVRAQ1P70EaCJQp+GitHimDIzhyS92M/nPy/hmd8tzoyvlbVabYLUJ/j7e6+njDuGBfiR2C2rQlbSgrMr7VUPGmGnGmO+NMZnGmHubOe4yY4wYY8a4Mx7lWr4+Fl74yRheuTGd7qH+/HXp994OSakW1Y6HOZ0SQXs1oF5X0qoaG6VVVqcai912J4wxPsB84EIgFZhtjElt5Lgw4OfAt+6KRbmPn4+FyQNimDOuD5tyClucElcpb+vMiSAlLoysvBKqrba6BWkivFwiSAcyRSRLRKqAhcDMRo77HfAnoOmVoVW7N2NET0IDfLnmxW/ZcbjI2+Eo1aRKq31AZGdMBAPiQqm2CvuPl1JYbm+383ZjcQJQv2NrjmNbHWPMKKCXiHzsxjiUB8SGBfLObePxMYbZL6xh68EW1kdWyktqSwQBbew+2p7Vzim062gJRworAYgObXnSSK/dCWOMBfg78Csnjp1rjMkwxmTk5mqDZHs1MD6MRbecSYi/L7e9vl6nolDtUmeuGuoXE4oxsPtoCdsO2T+MDe7R8hTZ7rwTB4Fe9R4nOrbVCgPSgOXGmH3AOGBxYw3GIvK8iIwRkTExMd7vs6ua1rt7MH++fBjZJ8p54vNd3g5HqVO0dpnKjiTI34de3YLZdayYrYeKSIgMIqqF1cnAvYlgHZBijEk2xvgDVwGLa3eKSKGIRItIkogkAWuAGSKS4caYlAdM6B/NNWN789zXWXy+/ai3w1GqgboSQSesGgJ7O8GuI8VsO1jIkJ7OLZjjtjshIjXAncBSYAewSES2GWMeNcbMcNfzqvbhoUuGMCg+jAfe31LXe0Gp9qAzVw0BjO4Txe5jJWTllTK2b3enznHrXEMisgRYctK2eU0cO8WdsSjP8ve18OfLh/Gj+Sv5/cfbmdA/mnMGxxEaoNNbKe/q7Ing5knJnCitxM/HwvXjk5w6R/8rldsMS4zk5kl9ee7rLBZl5HD9+CQenjHE22GpLq6yE7cRgH2g5/3TTxmy1azOeSdUu3H3eQPqFv3+bNsRnaBOeV1nbyNoC70Tyq0C/Xz44I4J/OuaURwqrODprzK9HZLq4jp71VBb6J1QbmeM4cK0eGaO6MnTX+3meEmlt0NSXZiWCE6ld0J5hDGG26f0p8YmfLT5sLfDUV1YZx5H0FZ6J5THDIwPI7VHOAtW7aOyRkcddyXvbsjhj5/s8HYYgFYNNUbvhPKoe6YNJCuvlH+v2OvtUJSHiAi/XLSJ5/6Xxao9ed4ORxNBI/ROKI+aOjCW81PjePrLTA4XliOivYg6u60Hf5iN9tn/ZXkxEru6qiFtI6ijd0J53IMXp1JltXHmH79izr+/xapdSju1FZn2UsDs9N6szMzjeEkly3Ye89r0I5XaWHwKvRPK43pFBXN+ahwAKzOP869lmTq+oBPbk1tCbFgA143vg9UmfLzlMDe8vI6bX8kgK7fE4/FU1djw8zFYLMbjz91eaSJQXvH4ZcN47trRnDs4lr99vosrn19NaWWNt8NSbrAnt4R+MaEMig9nQFxogyVNn/3fHo/HU1Vj09LASfRuKK+ICPLjgiHxvPCTMfxu5hDW7cvn4y3arbSzERH2HCuhf2woADOG96Sowp7wx/WN4rPtR6l21Nl7SpXVqg3FJ9G7obzKGMOccX1I6h7M2+tz2HaokPIq7VraWeSWVFJUUUO/mBAArh7bh2vH9eHeCwdx44RkCsqqWb3nuEdjqqqxEeDr49HnbO80ESivq00Ga/eeYPpTK/hLvaoD1XHZbMID720FYETvbgBEhfjzux+lcetZ/Zg8IIYQfx+WeLgkWFppJThAE0F9mghUu/DTicn84twUAD7cfEi7lXYC/16xl8+2H2XexamM6BV5yv5APx/OGRzH0m1HqPFg9VBpVY1Oh34STQSqXTDG8ItzB/Dny4eRW1zJun353g5JnaY31h5gfL/u3DAhqcljzh8SR35ZNVsOFnosrtLKGkL8NRHUp4lAtSsXpsUTHx7Ife9upqJa2wo6qoKyKvbmlTIxJRpjmu6meaZjBa1VHmwnKKm0EqJVQw1oIlDtSligH3+dNZw9uaUMevBT7nxjAwVlVa2+js0mrN9/QquYvGRzjv0T/ojEU6uE6useGsCg+DA+236UsirPdB8uq6ohRKuGGtBEoNqdiSnR3H3uAEb1juTTrUf4x5e7W32NdzbkcNkzq3l3w0E3RKhasjmnAIA0x6JEzZmd3ptN2QU8vHibu8MCHFVDmgga0ESg2qWfn5vCu7dPYMbwnixal01ucSWbsgu4+ZUMth8qavK8oopqPth4kN++sxmAP36yk6KKak+FrRyOFlXSLdiP8EC/Fo+9bnwSl45M4PPtRz0y3UhJpTYWn0wTgWrXbp3Sj9IqK2f8/gtmzl/J59uP8pOXvuXt9TkNjjtUUM7M+SsZ94cv+fnCjdjE3t5wvLSSRz/crvMZeVhxRTXhQS0ngVpTBsaQX1bNJkdJwl2sNqGi2kawv7YR1KdpUbVrA+LC+N3MIbyz4SDnD4ljYFwYT32Vya/f2sSnWw8zsX80hwor+P5IMZuyCxjRK5LfThuEiDCqTzf6fZXJP5dl0jsqmLvOSfH2y+kyiipqCAt0/u3lrAExBPn5MO+Drbx1y3iC3PRGXepoh9ASQUN6N1S7d+2ZSVx7ZlLd4ykDY5m/LJMFq/bxxY5j+FoMNTbhhglJPHTJkAbn/vqCgWzKKeDNddncObW/TjTmIUXl1U5VC9WKDPbnqdkjufmVDBas3setZ/VzS1y181lpG0FDejdUh+NjMdx1Tgq3ntWPvXml9IsJ4UhRBXHhgY0ef9moRH7x5kbW7TvBWEd3ReVexRU1JEUHt+qc81LjOGtADM/9bw/XnZnkllJBaaW9S7JWDTXk1jYCY8w0Y8z3xphMY8y9jey/1RizxRiz0RizwhiT6s54VOfi72thYHwYvj4WErsF49fEjJLnD4kj2N+H9zdqDyJPKapoXYmg1m1T+pFfVs2Hmw45fU5VjY0PNh6kxInZa2tLBFo11JDbEoExxgeYD1wIpAKzG3mjf0NEhorICODPwN/dFY/quoL9fZk2JJ6PNh926s1Cnb6i8tY1FtcamxzFwLgwXl97oNH9x4ormPfBVtbuPVG3bcGqffx84UYueOJrih09xESE/3tvCwtW7WtwvlYNNc6dJYJ0IFNEskSkClgIzKx/gIjU7wcYAmjXDuUWPxmfREllDY9/skMHmblZjdVGaZW1VY3FtYwxXDY6gU3ZBezLKz1l/x2vb+CV1fv5x5e7AHsvoJdW2te/PlRYzh+W7OS1NftJvm8Jb3x7gIcWb6tboxig1DGzrZYIGnJnIkgAsus9znFsa8AYc4cxZg/2EsFdboxHdWEjekVyw/hkXltzgLsWbuREaetHKyvn1Ja62lI1BHDxsJ4A/OhfK9lbLxlkHiupm4Nq3b58yqpqOHCijMOFFfz5smHMndSX/649wAPvb8VioFdUEABf7PhhScySSnuJQdsIGvL6OAIRmS8i/YDfAg80dowxZq4xJsMYk5Gbm+vZAFWn8cD0wdx1dn8+3XqYP32y09vhdFpF5fZE0JYSAUDPyCCevHIEBWXVPFdvBbMPNx3CYuAfV42gqsbGFzuOsTfPvtRlv9gQ7rlgINed2YdbzurLpofOZ/mvp9IjIpA319k/j24/VMT8ZXvoFuxHfETjHQu6KncmgoNAr3qPEx3bmrIQ+FFjO0TkeREZIyJjYmJiXBii6kosFsMvzx/I1em9eWdDDgcLyr0dUqdUO5K7LW0EtX40MoGrzujF+xsPkpNfBsC3e4+TlhDBxcN6khwdwgtfZ5GVay8xJEeH4utj4ZGZadx34WDCAv3wsRguH53I17tzWbbzGJc/u4pjRRXMv2YUwTr7aAPuTATrgBRjTLIxxh+4Clhc/wBjTP0RPtOB1k8qo1QrzT2rH8bQ4NOmcp26RNDGqqFat03ph5/Fwt1vbqSqxsZ3BwoY0ycKH4vhpxOT2XKwkA83HSI80JduwY0/15xxfYgPD+SGl9dRVmVl8Z0TGd8v+rTi6ozclhZFpMYYcyewFPABXhKRbcaYR4EMEVkM3GmMOReoBvKB69wVj1K1EiKDuHx0Iq9/e4Diihr25JZw77RBjOzdjWqb7bTfwLq6onJ7Imhr1VCtPt1D+NX5A3j4w+0MeOATAM5Isq90dsmwnjy8eBubcgoZ3iuyyamu48IDee/2Cfx7RRZJ0SEkRYecVkydlVvLRyKyBFhy0rZ59X7+uTufX6mm3D89ldziKt77zl5befWL3+JjMVhtwqD4MCb2j2bDgXxmjenFRUN7EHEa1RxdzdGiSgBiwwNO+1qXjkrk4Q+3A/aBgZMH2KuGI4L9mDools+3H2V4CzOcxkcEcv90HaLUHNPRutKNGTNGMjIyvB2G6gREhOXf5xIZ7MfSbUfx8zEE+vmwbOcxNhzIp/48dX++bBhXnNGL4opq9uWVMdSJ6ZW7qj99upMXvs5i12MXumRKj29259It2J+0hIb3/HhJJfuOlzI8MRLfJgYTqh8YY9aLyJjG9mmLieqyjDFMHRQLwEjH4uoAd0ztj80mHDhRxq2vrcfXx/Cbdzbz+toDbMouwBh497bxDc5RPzhaaJ/uw1XzOk1KabyDSPfQALqHnn6pQ7WD7qNKtUcWiyEpOoRPfzGZd2+bwM2Tkil0rJQW6OvDwx9u14FpTbDP+6Rv0B2JlgiUaoG/r4X7p6dy34WDycor5du9x7n/va2syTrBmf10EruTHSmqYFB8mLfDUK2gJQKlnGSxGPrHhnLZqERiwwJ4aPFWyh1TFqgf1FYNqY5DE4FSrRTo58NfZw1n19ESXluz39vheNTxkkp2Hy1ucn9RRTWlVVbiNRF0KJoIlGqDyQNiSE+K4pU1+7rUMpj3vbuF8574mj8s2dHo/mU7jwEwLDHSk2Gp06SJQKk2unFiEtknyuvGInRmIsKqzDyWfW9/o3/+6yzufnMjd7y+gUP1pup4/7uD9IgIZGxylLdCVW2giUCpNrpgSDzDEyP422ffU1HdudsKPtt+lKtf/JZqq/C3WcM5d3As7313kKXbjnDpv1ayL68Uq01Yk3WC81PjdEnQDkYTgVJtZIzh3gsHc7iw4pQFUDqb2hk8ASalRPPctWNYctckPr5rEhXVNn7zzmb25pVSXm1lSIIOtutoNBEodRrO7NedcX2jWLguu9ONK7DZhJdW7OWaF9fw1c5j3HJWX5b+YjKx4YH4WAypPcMZGB/GPRcMZO3eEzz4/lYAhvQM93LkqrU0ESh1mi4e1pO9eaV830xvmo7oX8szefSj7azMPA7A3El9GdjI+IDZ6b2ZPqwHq7OO4+djSInVMQQdjQ4oU+o0XTAknkc/2s4tr67nrVvPJDas43edPFhQzlNfZjJ9WA8mp0QTGuDX5HQOPhbDk1eOAKCssgZ/X/182dFoIlDqNMWEBfDKjenMefFbfvfRDuZO6kvfmJAOvUD6f1bsxSrC/100mITIoBaP9/OxMP/qUZ2ueqyr0NStlAuM69udq9J78eGmQ1zyzxXc9+4Wb4fUZqv3HOeV1fu5ZFgPp5JAfU2tC6Dat477kUWpdubhS4YwOSWGfy3fw4ebD3HgRBlRIf78+7oxHeoN8t8rsuge6s8jM9O8HYryEC0RKOUivj4Wzh8Sz3+uP4OeEUFszC7gq53HWP59rrdDa5VDBRWk9gjXxXi6EE0ESrlYtxB/ltw1iWfnjKZHRCB/Wfo91Vabt8Ny2uHCcnpEdvwGb+U8TQRKuUFEsB/T0uJ5eMYQth8u4v73tlDgWM+gPauotpJfVk2PiNa1DaiOTROBUm50wZB4bpncl0UZOUz80zKWbjvCZc+s4rsD+XXHHC+p9GKEDR0prADQ2UO7GE0ESrnZvRcO4tWfphPs78Mtr65n/f58frVoE8eKK3j92/2MfuwLFq49QFZuCdknyrwa66FC+wRyPSI0EXQl2mtIKTczxjApJYa3bx3PE1/sYk9uCZtzCkn//ZcA+PkYHlq8DWOgotrGX2cN5/LRiS557mNFFYQH+RHo5+PU8bUlgh6t7DaqOjZNBEp5SO/uwTxx5QiqamyszMxjx5EifC2G81LjueK51ZworSI5OoR5H2zFZhOuOKPXKdeorLES4Ovcm3q11cZFT60gLjyARbec6dQAt9oppbVqqGvRRKCUh/n7Wpg6KJapg2Lrtr13+3gqqm2EBfpy13+/4zfvbMZiMVw2KoFqq7App4C/f7aL77Lz+fiuSfSLCW3xeVbvOU5eSSV5JZX8fOF3zL9mVItJZP/xMmLDAgjydy7ZqM7BrYnAGDMN+AfgA7woIo+ftP+XwE1ADZAL3CgiXWvtP6WAxG7BdT+/dtNYrv/PWu57dzP/WbmX7YeLEIHo0ACqrcI5f/sfI3tHkhwdQnL3ELqHBvDqmv0UlFVx//TBXDysJwCfbD1MaIAvvzg3hcc+3sHkPy/jyjG9uPu8AU0OcDtwoozeUcGN7lOdl9sSgTHGB5gPnAfkAOuMMYtFZHu9w74DxohImTHmNuDPwJXuikmpjsDPx8K/rhnN7OfXsO1QEYPiw5id3psrxvTiiS92sXDtAfx9LHy54xiF5dUADE+MICzQlzvf+I6ySis/HpXA0m1HOXtQLDc55j568Zu9PPVVJn4+Fn52TkqD59x9tJiQAF+yT5Qxrl93b7xs5UXuLBGkA5kikgVgjFkIzATqEoGILKt3/BpgjhvjUarDiAjy461bz+Tz7UeZlhZf19h777RB/HbaIHwcK4D9YckODhdW8PcrhmO1CTctyGDe4q1sO1TIidIqLhoaD8DZg+KYOjCWuxZu5KmvdnPh0B70jw1lS04hv3prI7uOlhAXHsDRokotEXRB7kwECUB2vcc5wNhmjv8p8Ikb41GqQwkJ8OVHIxMabDt5Ccj/u2hw3c9+PvDXWcOZOX8FC1bvJyEyiLMG/NAOYYzh4UtS+XLHUZ74YhcVVVa+3HmMYH8fpgyMqZsKQxNB19MuGouNMXOAMcBZTeyfC8wF6N27twcjU6pjiY8I5JvfnI1NhABfyyltAd1DA7j2zD4897+sum3zrx7F1EGxfLDxIG+uy+ZMrRrqctyZCA4C9fu/JTq2NWCMORe4HzhLRBodYikizwPPA4wZM0YnPFeqGS0tDHP3uQMor7JSbRX+cGlaXbKYOSKBmSMSmj1XdU7uTATrgBRjTDL2BHAVcHX9A4wxI4HngGkicsyNsSilHAL9fHhUp5hW9bhtigkRqQHuBJYCO4BFIrLNGPOoMWaG47C/AKHAW8aYjcaYxe6KRymlVOPc2kYgIkuAJSdtm1fv53Pd+fxKKaVappPOKaVUF6eJQCmlujhNBEop1cVpIlBKqS5OE4FSSnVxmgiUUqqLMyIda6CuMSYXcNVU1RFAoYfOd+bYlo5pan9j253ZFg3ktRCTq3jyXjt7fHPHdOR73djzu/N8T97rxrbrvXbumD4iEtPoGSLSZb+A5z11vjPHtnRMU/sb2+7MNiCjM95rV9zvjnyvPX2/PXmvm7i3eq9PM56uXjX0oQfPd+bYlo5pan9j253d5imevNfOHt/cMR35Xrvi+T35t92ae93Ydr3Xbb8e0AGrhpTrGGMyRGSMt+PoCvRee47e69br6iWCru55bwfQhei99hy9162kJQKllOritESglFJdnCYCpZTq4jQRKKVUF6eJQDXKGDPFGPONMeZZY8wUb8fT2RljQowxGcaYi70dS2dmjBns+Jt+2xhzZ9ckAwAABORJREFUm7fjaS80EXRCxpiXjDHHjDFbT9o+zRjzvTEm0xhzbwuXEaAECARy3BVrR+eiew3wW2CRe6LsHFxxr0Vkh4jcClwBTHBnvB2J9hrqhIwxk7G/ib8iImmObT7ALuA87G/s64DZgA/wx5MucSOQJyI2Y0wc8HcRucZT8XckLrrXw4Hu2JNunoh85JnoOxZX3GsROeZYKvc24FURecNT8bdnbl2qUnmHiHxtjEk6aXM6kCkiWQDGmIXATBH5I9BcdUQ+EOCOODsDV9xrR9VbCJAKlBtjloiIzZ1xd0Su+rsWkcXAYmPMx4AmAjQRdCUJQHa9xznA2KYONsb8GLgAiAT+6d7QOp1W3WsRuR/AGHM9jpKYW6PrXFr7dz0F+DH2DzdLmjquq9FEoBolIu8C73o7jq5ERF72dgydnYgsB5Z7OYx2RxuLu46DQK96jxMd25Tr6b32HL3XLqCJoOtYB6QYY5KNMf7AVcBiL8fUWem99hy91y6giaATMsb8F1gNDDTG5BhjfioiNcCdwFJgB7BIRLZ5M87OQO+15+i9dh/tPqqUUl2clgiUUqqL00SglFJdnCYCpZTq4jQRKKVUF6eJQCmlujhNBEop1cVpIlCdhjGmxMPPt8rDzxdpjLndk8+pugZNBEo1wRjT7FxcIjLew88ZCWgiUC6niUB1asaYfsaYT40x6x0rrg1ybL/EGPOtMeY7Y8wXjnUXMMY8bIx51RizEnjV8fglY8xyY0yWMeauetcucXyf4tj/tjFmpzHmdWOMcey7yLFtvTHmKWPMKWsNGGOuN8YsNsZ8BXxpjAk1xnxpjNlgjNlijJnpOPRxoJ8xZqMx5i+Oc+8xxqwzxmw2xjziznupOjER0S/96hRfQEkj274EUhw/jwW+cvzcjR9G1t8E/M3x88PAeiCo3uNV2KctjgaOA371nw+YAhRin/DMgn0ahInYF5rJBpIdx/0X+KiRGK/HPn1ylOOxLxDu+DkayAQM8P/t3b1rFEEcxvHvE9BCTlJpEAVfwMJKwc5CsMl/IBYKgqD/gZ2FlXZaiEjsRSVdVFQEC0EEEVSMoAjGwurAF/RCOMQ8Fjsha7zIiTmit88HBm5vZnbmOO5+O7PLzDZgulZvHLhc8kaAm8D+1f4ekv6/lGWoY2hJagH7gMlygQ6Lm+xsAa5L2gSsBWZqVadsz9WOb9nuAl1JbWCMX7fvfGz7fWn3GdWfdgd4a3vh3FeBE8t0957tjwtdB86UHbnmqdbcH+tRZ7ykp+W4BewEHizTRkRPCQQxzEaAz7b39Mi7QLUF51TZrOR0LW92Sdlu7fV3ev9u+inzO/U2DwMbgL22v0l6RzW6WErAWdsTf9hWxE9yjyCGlu0vwIykgwCq7C7ZoyyuW390QF14Deyoba94qM96o0C7BIEDwNby/ldgfa3cXeBYGfkgabOkjX/d62icjAhimKyTVJ+yOUd1dX1J0ilgDXANeE41ApiU9Am4D2xf6c7YniuPe96RNEu1dn4/rgA3JL0AngCvyvk+SHooaRq4bfukpF3AozL11QGOAO2V/iwx3LIMdcQASWrZ7pSniC4Cb2yfX+1+RdRlaihisI6Xm8cvqaZ8Mp8f/5yMCCIiGi4jgoiIhksgiIhouASCiIiGSyCIiGi4BIKIiIZLIIiIaLgfKFx/TS6PY/4AAAAASUVORK5CYII=",
       "text/plain": [
@@ -287,67 +289,68 @@
      "metadata": {
       "needs_background": "light",
       "tags": []
-     }
+     },
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Suggested LR 1.0148376909312998e-05\n"
      ]
     }
    ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 300
-    },
-    "id": "oN0VkPapmvd5",
-    "outputId": "b2f3fc64-046e-43a4-cd7a-e604003b8c6f"
-   }
+   "source": [
+    "lr_finder.plot()\n",
+    "\n",
+    "print(\"Suggested LR\", lr_finder.lr_suggestion())"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Now we will apply the suggested learning rate to the optimizer, and train the model again with optimal learning rate."
-   ],
    "metadata": {
     "id": "NcT19wqkmvd6"
-   }
+   },
+   "source": [
+    "Now we will apply the suggested learning rate to the optimizer, and train the model again with optimal learning rate."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "source": [
-    "lr_finder.apply_suggested_lr(optimizer)\n",
-    "print(optimizer.param_groups[0][\"lr\"])"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "1.0148376909312998e-05\n"
-     ]
-    }
-   ],
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "id": "GtEYvL92RDXU",
     "outputId": "fdc40ae4-8c0e-473f-8ae5-1d44d4cb8f9f"
-   }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.0148376909312998e-05\n"
+     ]
+    }
+   ],
+   "source": [
+    "lr_finder.apply_suggested_lr(optimizer)\n",
+    "print(optimizer.param_groups[0][\"lr\"])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "source": [
-    "trainer.run(train_loader, max_epochs=3)"
-   ],
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DJqgyaFnmvd7",
+    "outputId": "bb1f62d5-c72e-45a7-b547-5a44b05f9efe"
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
@@ -363,53 +366,50 @@
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 30,
      "metadata": {
       "tags": []
      },
-     "execution_count": 30
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "DJqgyaFnmvd7",
-    "outputId": "bb1f62d5-c72e-45a7-b547-5a44b05f9efe"
-   }
+   "source": [
+    "trainer.run(train_loader, max_epochs=3)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "source": [
-    "# Calculate the new metrics after using the optimal lr\n",
-    "evaluator.run(test_loader)\n",
-    "print(evaluator.state.metrics)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "{'Accuracy': 0.9715, 'Loss': 0.0908882568359375}\n"
-     ]
-    }
-   ],
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "id": "MU8E7PpleaNm",
     "outputId": "e308fcaa-92af-462b-9148-e64ec1532a34"
-   }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Accuracy': 0.9715, 'Loss': 0.0908882568359375}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Calculate the new metrics after using the optimal lr\n",
+    "evaluator.run(test_loader)\n",
+    "print(evaluator.state.metrics)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "As we saw the accuracy increased and loss decreased on the test dataset when we trained our model for the same number of epochs with an optimal learning rate."
-   ],
    "metadata": {
     "id": "ejVpTNh3MJc2"
-   }
+   },
+   "source": [
+    "As we saw the accuracy increased and loss decreased on the test dataset when we trained our model for the same number of epochs with an optimal learning rate."
+   ]
   }
  ],
  "metadata": {

--- a/how-to-guides/05-gradient-accumulation.ipynb
+++ b/how-to-guides/05-gradient-accumulation.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "8a652d9a",
    "metadata": {},
    "source": [
     "<!-- ---\n",
@@ -24,6 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "dd80e226",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,6 +52,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c74f90a0",
    "metadata": {},
    "source": [
     "If you prefer to use the PyTorch-Ignite helper functions for supervised training mentioned [here](https://pytorch.org/ignite/engine.html#helper-methods-to-define-supervised-trainer-and-evaluator), they also support Gradient Accumulation through the ``gradient_accumulation_steps`` parameter. \n",
@@ -64,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a7c4ea05",
    "metadata": {},
    "source": [
     "## Resources\n",
@@ -77,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4fcc2d56",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -84,7 +89,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -98,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/how-to-guides/06-data-iterator.ipynb
+++ b/how-to-guides/06-data-iterator.ipynb
@@ -2,6 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "55c7fada",
+   "metadata": {},
    "source": [
     "<!-- ---\n",
     "title: How to work with data iterators\n",
@@ -21,21 +23,66 @@
     "examples of how to setup trainer or evaluator.\n",
     "\n",
     "<!--more-->"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e97045a5",
+   "metadata": {},
    "source": [
     "## Infinite iterator for training\n",
     "\n",
     "Let’s use an infinite data iterator as training dataflow"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "5b5f175a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/3 : 1 - 63.862\n",
+      "1/3 : 2 - 64.042\n",
+      "1/3 : 3 - 63.936\n",
+      "1/3 : 4 - 64.141\n",
+      "1/3 : 5 - 64.767\n",
+      "2/3 : 6 - 63.791\n",
+      "2/3 : 7 - 64.565\n",
+      "2/3 : 8 - 63.602\n",
+      "2/3 : 9 - 63.995\n",
+      "2/3 : 10 - 63.943\n",
+      "3/3 : 11 - 63.831\n",
+      "3/3 : 12 - 64.276\n",
+      "3/3 : 13 - 64.148\n",
+      "3/3 : 14 - 63.920\n",
+      "3/3 : 15 - 64.226\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 15\n",
+       "\tepoch: 3\n",
+       "\tepoch_length: 5\n",
+       "\tmax_epochs: 3\n",
+       "\toutput: <class 'NoneType'>\n",
+       "\tbatch: <class 'torch.Tensor'>\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'generator'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import torch\n",
     "from ignite.engine import Engine, Events\n",
@@ -58,38 +105,51 @@
     "\n",
     "# We need to specify epoch_length to define the epoch\n",
     "trainer.run(infinite_iterator(4), epoch_length=5, max_epochs=3)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a755b048",
+   "metadata": {},
+   "source": [
+    "If we do not specify **epoch_length**, we can stop the training explicitly by calling [`terminate()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine). In this case, there will be only a single epoch defined."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d48531dd",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1/3 : 1 - 63.862\n",
-      "1/3 : 2 - 64.042\n",
-      "1/3 : 3 - 63.936\n",
-      "1/3 : 4 - 64.141\n",
-      "1/3 : 5 - 64.767\n",
-      "2/3 : 6 - 63.791\n",
-      "2/3 : 7 - 64.565\n",
-      "2/3 : 8 - 63.602\n",
-      "2/3 : 9 - 63.995\n",
-      "2/3 : 10 - 63.943\n",
-      "3/3 : 11 - 63.831\n",
-      "3/3 : 12 - 64.276\n",
-      "3/3 : 13 - 64.148\n",
-      "3/3 : 14 - 63.920\n",
-      "3/3 : 15 - 64.226\n"
+      "1/1 : 1 - 63.862\n",
+      "1/1 : 2 - 64.042\n",
+      "1/1 : 3 - 63.936\n",
+      "1/1 : 4 - 64.141\n",
+      "1/1 : 5 - 64.767\n",
+      "1/1 : 6 - 63.791\n",
+      "1/1 : 7 - 64.565\n",
+      "1/1 : 8 - 63.602\n",
+      "1/1 : 9 - 63.995\n",
+      "1/1 : 10 - 63.943\n",
+      "1/1 : 11 - 63.831\n",
+      "1/1 : 12 - 64.276\n",
+      "1/1 : 13 - 64.148\n",
+      "1/1 : 14 - 63.920\n",
+      "1/1 : 15 - 64.226\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
        "\titeration: 15\n",
-       "\tepoch: 3\n",
-       "\tepoch_length: 5\n",
-       "\tmax_epochs: 3\n",
+       "\tepoch: 1\n",
+       "\tepoch_length: <class 'NoneType'>\n",
+       "\tmax_epochs: 1\n",
        "\toutput: <class 'NoneType'>\n",
        "\tbatch: <class 'torch.Tensor'>\n",
        "\tmetrics: <class 'dict'>\n",
@@ -98,22 +158,11 @@
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 1
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "If we do not specify **epoch_length**, we can stop the training explicitly by calling [`terminate()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine). In this case, there will be only a single epoch defined."
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "source": [
     "import torch\n",
     "from ignite.engine import Engine, Events\n",
@@ -139,61 +188,20 @@
     "    trainer.terminate()\n",
     "\n",
     "trainer.run(infinite_iterator(4))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "1/1 : 1 - 63.862\n",
-      "1/1 : 2 - 64.042\n",
-      "1/1 : 3 - 63.936\n",
-      "1/1 : 4 - 64.141\n",
-      "1/1 : 5 - 64.767\n",
-      "1/1 : 6 - 63.791\n",
-      "1/1 : 7 - 64.565\n",
-      "1/1 : 8 - 63.602\n",
-      "1/1 : 9 - 63.995\n",
-      "1/1 : 10 - 63.943\n",
-      "1/1 : 11 - 63.831\n",
-      "1/1 : 12 - 64.276\n",
-      "1/1 : 13 - 64.148\n",
-      "1/1 : 14 - 63.920\n",
-      "1/1 : 15 - 64.226\n"
-     ]
-    },
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "State:\n",
-       "\titeration: 15\n",
-       "\tepoch: 1\n",
-       "\tepoch_length: <class 'NoneType'>\n",
-       "\tmax_epochs: 1\n",
-       "\toutput: <class 'NoneType'>\n",
-       "\tbatch: <class 'torch.Tensor'>\n",
-       "\tmetrics: <class 'dict'>\n",
-       "\tdataloader: <class 'generator'>\n",
-       "\tseed: <class 'NoneType'>\n",
-       "\ttimes: <class 'dict'>"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 2
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "30d63d14",
+   "metadata": {},
    "source": [
     "Same code can be used for validating models."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "37190708",
+   "metadata": {},
    "source": [
     "### Finite iterator with unknown length\n",
     "\n",
@@ -202,42 +210,17 @@
     "dataflow and thus we need to restart the data iterator when it is\n",
     "exhausted. In the code, we do not specify `epoch_length` which will be automatically\n",
     "determined."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "import torch\n",
-    "from ignite.engine import Engine, Events\n",
-    "\n",
-    "torch.manual_seed(12)\n",
-    "\n",
-    "def finite_unk_size_data_iter():\n",
-    "    for i in range(11):\n",
-    "        yield i\n",
-    "\n",
-    "def train_step(trainer, batch):\n",
-    "    # ...\n",
-    "    s = trainer.state\n",
-    "    print(\n",
-    "        f\"{s.epoch}/{s.max_epochs} : {s.iteration} - {batch:.3f}\"\n",
-    "    )\n",
-    "\n",
-    "trainer = Engine(train_step)\n",
-    "\n",
-    "@trainer.on(Events.DATALOADER_STOP_ITERATION)\n",
-    "def restart_iter():\n",
-    "    trainer.state.dataloader = finite_unk_size_data_iter()\n",
-    "\n",
-    "data_iter = finite_unk_size_data_iter()\n",
-    "trainer.run(data_iter, max_epochs=5)"
-   ],
+   "id": "199087b1",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "1/5 : 1 - 0.000\n",
       "1/5 : 2 - 1.000\n",
@@ -297,7 +280,6 @@
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
@@ -313,22 +295,90 @@
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "import torch\n",
+    "from ignite.engine import Engine, Events\n",
+    "\n",
+    "torch.manual_seed(12)\n",
+    "\n",
+    "def finite_unk_size_data_iter():\n",
+    "    for i in range(11):\n",
+    "        yield i\n",
+    "\n",
+    "def train_step(trainer, batch):\n",
+    "    # ...\n",
+    "    s = trainer.state\n",
+    "    print(\n",
+    "        f\"{s.epoch}/{s.max_epochs} : {s.iteration} - {batch:.3f}\"\n",
+    "    )\n",
+    "\n",
+    "trainer = Engine(train_step)\n",
+    "\n",
+    "@trainer.on(Events.DATALOADER_STOP_ITERATION)\n",
+    "def restart_iter():\n",
+    "    trainer.state.dataloader = finite_unk_size_data_iter()\n",
+    "\n",
+    "data_iter = finite_unk_size_data_iter()\n",
+    "trainer.run(data_iter, max_epochs=5)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ee068ac8",
+   "metadata": {},
    "source": [
     "In case of validation, the code is simply"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "beae6490",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 : 1 - 0.000\n",
+      "1/1 : 2 - 1.000\n",
+      "1/1 : 3 - 2.000\n",
+      "1/1 : 4 - 3.000\n",
+      "1/1 : 5 - 4.000\n",
+      "1/1 : 6 - 5.000\n",
+      "1/1 : 7 - 6.000\n",
+      "1/1 : 8 - 7.000\n",
+      "1/1 : 9 - 8.000\n",
+      "1/1 : 10 - 9.000\n",
+      "1/1 : 11 - 10.000\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 11\n",
+       "\tepoch: 1\n",
+       "\tepoch_length: 11\n",
+       "\tmax_epochs: 1\n",
+       "\toutput: <class 'NoneType'>\n",
+       "\tbatch: <class 'NoneType'>\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'generator'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import torch\n",
     "from ignite.engine import Engine, Events\n",
@@ -350,60 +400,106 @@
     "\n",
     "data_iter = finite_unk_size_data_iter()\n",
     "evaluator.run(data_iter)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d1abaa7",
+   "metadata": {},
+   "source": [
+    "### Finite iterator with known length\n",
+    "\n",
+    "Let's use a finite data iterator with known size for training or validation. If we need to restart the data iterator, we can do this either as in case of unknown size by attaching the restart handler on `@trainer.on(Events.DATALOADER_STOP_ITERATION)`, but here we will do this explicitly on iteration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a7f519ac",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1/1 : 1 - 0.000\n",
-      "1/1 : 2 - 1.000\n",
-      "1/1 : 3 - 2.000\n",
-      "1/1 : 4 - 3.000\n",
-      "1/1 : 5 - 4.000\n",
-      "1/1 : 6 - 5.000\n",
-      "1/1 : 7 - 6.000\n",
-      "1/1 : 8 - 7.000\n",
-      "1/1 : 9 - 8.000\n",
-      "1/1 : 10 - 9.000\n",
-      "1/1 : 11 - 10.000\n"
+      "1/5 : 1 - 0.000\n",
+      "1/5 : 2 - 1.000\n",
+      "1/5 : 3 - 2.000\n",
+      "1/5 : 4 - 3.000\n",
+      "1/5 : 5 - 4.000\n",
+      "1/5 : 6 - 5.000\n",
+      "1/5 : 7 - 6.000\n",
+      "1/5 : 8 - 7.000\n",
+      "1/5 : 9 - 8.000\n",
+      "1/5 : 10 - 9.000\n",
+      "1/5 : 11 - 10.000\n",
+      "2/5 : 12 - 0.000\n",
+      "2/5 : 13 - 1.000\n",
+      "2/5 : 14 - 2.000\n",
+      "2/5 : 15 - 3.000\n",
+      "2/5 : 16 - 4.000\n",
+      "2/5 : 17 - 5.000\n",
+      "2/5 : 18 - 6.000\n",
+      "2/5 : 19 - 7.000\n",
+      "2/5 : 20 - 8.000\n",
+      "2/5 : 21 - 9.000\n",
+      "2/5 : 22 - 10.000\n",
+      "3/5 : 23 - 0.000\n",
+      "3/5 : 24 - 1.000\n",
+      "3/5 : 25 - 2.000\n",
+      "3/5 : 26 - 3.000\n",
+      "3/5 : 27 - 4.000\n",
+      "3/5 : 28 - 5.000\n",
+      "3/5 : 29 - 6.000\n",
+      "3/5 : 30 - 7.000\n",
+      "3/5 : 31 - 8.000\n",
+      "3/5 : 32 - 9.000\n",
+      "3/5 : 33 - 10.000\n",
+      "4/5 : 34 - 0.000\n",
+      "4/5 : 35 - 1.000\n",
+      "4/5 : 36 - 2.000\n",
+      "4/5 : 37 - 3.000\n",
+      "4/5 : 38 - 4.000\n",
+      "4/5 : 39 - 5.000\n",
+      "4/5 : 40 - 6.000\n",
+      "4/5 : 41 - 7.000\n",
+      "4/5 : 42 - 8.000\n",
+      "4/5 : 43 - 9.000\n",
+      "4/5 : 44 - 10.000\n",
+      "5/5 : 45 - 0.000\n",
+      "5/5 : 46 - 1.000\n",
+      "5/5 : 47 - 2.000\n",
+      "5/5 : 48 - 3.000\n",
+      "5/5 : 49 - 4.000\n",
+      "5/5 : 50 - 5.000\n",
+      "5/5 : 51 - 6.000\n",
+      "5/5 : 52 - 7.000\n",
+      "5/5 : 53 - 8.000\n",
+      "5/5 : 54 - 9.000\n",
+      "5/5 : 55 - 10.000\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
-       "\titeration: 11\n",
-       "\tepoch: 1\n",
+       "\titeration: 55\n",
+       "\tepoch: 5\n",
        "\tepoch_length: 11\n",
-       "\tmax_epochs: 1\n",
+       "\tmax_epochs: 5\n",
        "\toutput: <class 'NoneType'>\n",
-       "\tbatch: <class 'NoneType'>\n",
+       "\tbatch: 10\n",
        "\tmetrics: <class 'dict'>\n",
        "\tdataloader: <class 'generator'>\n",
        "\tseed: <class 'NoneType'>\n",
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 4
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "### Finite iterator with known length\n",
-    "\n",
-    "Let's use a finite data iterator with known size for training or validation. If we need to restart the data iterator, we can do this either as in case of unknown size by attaching the restart handler on `@trainer.on(Events.DATALOADER_STOP_ITERATION)`, but here we will do this explicitly on iteration:"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "source": [
     "import torch\n",
     "from ignite.engine import Engine, Events\n",
@@ -431,102 +527,60 @@
     "\n",
     "data_iter = finite_size_data_iter(size)\n",
     "trainer.run(data_iter, max_epochs=5)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a518b014",
+   "metadata": {},
+   "source": [
+    "In case of validation, the code is simply"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d1402c18",
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "1/5 : 1 - 0.000\n",
-      "1/5 : 2 - 1.000\n",
-      "1/5 : 3 - 2.000\n",
-      "1/5 : 4 - 3.000\n",
-      "1/5 : 5 - 4.000\n",
-      "1/5 : 6 - 5.000\n",
-      "1/5 : 7 - 6.000\n",
-      "1/5 : 8 - 7.000\n",
-      "1/5 : 9 - 8.000\n",
-      "1/5 : 10 - 9.000\n",
-      "1/5 : 11 - 10.000\n",
-      "2/5 : 12 - 0.000\n",
-      "2/5 : 13 - 1.000\n",
-      "2/5 : 14 - 2.000\n",
-      "2/5 : 15 - 3.000\n",
-      "2/5 : 16 - 4.000\n",
-      "2/5 : 17 - 5.000\n",
-      "2/5 : 18 - 6.000\n",
-      "2/5 : 19 - 7.000\n",
-      "2/5 : 20 - 8.000\n",
-      "2/5 : 21 - 9.000\n",
-      "2/5 : 22 - 10.000\n",
-      "3/5 : 23 - 0.000\n",
-      "3/5 : 24 - 1.000\n",
-      "3/5 : 25 - 2.000\n",
-      "3/5 : 26 - 3.000\n",
-      "3/5 : 27 - 4.000\n",
-      "3/5 : 28 - 5.000\n",
-      "3/5 : 29 - 6.000\n",
-      "3/5 : 30 - 7.000\n",
-      "3/5 : 31 - 8.000\n",
-      "3/5 : 32 - 9.000\n",
-      "3/5 : 33 - 10.000\n",
-      "4/5 : 34 - 0.000\n",
-      "4/5 : 35 - 1.000\n",
-      "4/5 : 36 - 2.000\n",
-      "4/5 : 37 - 3.000\n",
-      "4/5 : 38 - 4.000\n",
-      "4/5 : 39 - 5.000\n",
-      "4/5 : 40 - 6.000\n",
-      "4/5 : 41 - 7.000\n",
-      "4/5 : 42 - 8.000\n",
-      "4/5 : 43 - 9.000\n",
-      "4/5 : 44 - 10.000\n",
-      "5/5 : 45 - 0.000\n",
-      "5/5 : 46 - 1.000\n",
-      "5/5 : 47 - 2.000\n",
-      "5/5 : 48 - 3.000\n",
-      "5/5 : 49 - 4.000\n",
-      "5/5 : 50 - 5.000\n",
-      "5/5 : 51 - 6.000\n",
-      "5/5 : 52 - 7.000\n",
-      "5/5 : 53 - 8.000\n",
-      "5/5 : 54 - 9.000\n",
-      "5/5 : 55 - 10.000\n"
+      "1/1 : 1 - 0.000\n",
+      "1/1 : 2 - 1.000\n",
+      "1/1 : 3 - 2.000\n",
+      "1/1 : 4 - 3.000\n",
+      "1/1 : 5 - 4.000\n",
+      "1/1 : 6 - 5.000\n",
+      "1/1 : 7 - 6.000\n",
+      "1/1 : 8 - 7.000\n",
+      "1/1 : 9 - 8.000\n",
+      "1/1 : 10 - 9.000\n",
+      "1/1 : 11 - 10.000\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "State:\n",
-       "\titeration: 55\n",
-       "\tepoch: 5\n",
+       "\titeration: 11\n",
+       "\tepoch: 1\n",
        "\tepoch_length: 11\n",
-       "\tmax_epochs: 5\n",
+       "\tmax_epochs: 1\n",
        "\toutput: <class 'NoneType'>\n",
-       "\tbatch: 10\n",
+       "\tbatch: <class 'NoneType'>\n",
        "\tmetrics: <class 'dict'>\n",
        "\tdataloader: <class 'generator'>\n",
        "\tseed: <class 'NoneType'>\n",
        "\ttimes: <class 'dict'>"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "In case of validation, the code is simply"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
    "source": [
     "import torch\n",
     "from ignite.engine import Engine, Events\n",
@@ -550,53 +604,17 @@
     "\n",
     "data_iter = finite_size_data_iter(size)\n",
     "evaluator.run(data_iter)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "1/1 : 1 - 0.000\n",
-      "1/1 : 2 - 1.000\n",
-      "1/1 : 3 - 2.000\n",
-      "1/1 : 4 - 3.000\n",
-      "1/1 : 5 - 4.000\n",
-      "1/1 : 6 - 5.000\n",
-      "1/1 : 7 - 6.000\n",
-      "1/1 : 8 - 7.000\n",
-      "1/1 : 9 - 8.000\n",
-      "1/1 : 10 - 9.000\n",
-      "1/1 : 11 - 10.000\n"
-     ]
-    },
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "State:\n",
-       "\titeration: 11\n",
-       "\tepoch: 1\n",
-       "\tepoch_length: 11\n",
-       "\tmax_epochs: 1\n",
-       "\toutput: <class 'NoneType'>\n",
-       "\tbatch: <class 'NoneType'>\n",
-       "\tmetrics: <class 'dict'>\n",
-       "\tdataloader: <class 'generator'>\n",
-       "\tseed: <class 'NoneType'>\n",
-       "\ttimes: <class 'dict'>"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 6
-    }
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "668c1b3fdfcad7da09e9c177fb24f18a657bbc5f55005750960a78843b3807f7"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.10 64-bit ('pytorch-ignite-dev': conda)"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -609,9 +627,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.10"
-  },
-  "interpreter": {
-   "hash": "668c1b3fdfcad7da09e9c177fb24f18a657bbc5f55005750960a78843b3807f7"
   }
  },
  "nbformat": 4,

--- a/how-to-guides/07-cross-validation.ipynb
+++ b/how-to-guides/07-cross-validation.ipynb
@@ -1,1958 +1,1955 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "original cross-validation.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.10"
-    },
-    "pycharm": {
-      "stem_cell": {
-        "cell_type": "raw",
-        "metadata": {
-          "collapsed": false
-        },
-        "source": []
-      }
-    },
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "2ecac1db4380427ea8f79c687b272485": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_af9a6e72e0e7429b9bd1b0b29ac64004",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_201226132da544fda85023e02e753bd0",
-              "IPY_MODEL_15f004ed0b0944eb8a5e71ad2b510445",
-              "IPY_MODEL_743a448619e04af8b000f2a48a4edffb"
-            ]
-          }
-        },
-        "af9a6e72e0e7429b9bd1b0b29ac64004": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "201226132da544fda85023e02e753bd0": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_7d5650b586e64670a7e4a2d2f0a6aa0c",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_65c9cc7ae37242a4ba1b418e185dba52"
-          }
-        },
-        "15f004ed0b0944eb8a5e71ad2b510445": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_187efadb840b4fa0bc4d093f5055c14a",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 9912422,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 9912422,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_c191b634893c4f8fa9fe178707f30359"
-          }
-        },
-        "743a448619e04af8b000f2a48a4edffb": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_d4d84fa7fa014c00a310fff00b0120dc",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 9913344/? [00:00&lt;00:00, 53561559.59it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_b391e2d3983645518245600c65ecdcf1"
-          }
-        },
-        "7d5650b586e64670a7e4a2d2f0a6aa0c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "65c9cc7ae37242a4ba1b418e185dba52": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "187efadb840b4fa0bc4d093f5055c14a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "c191b634893c4f8fa9fe178707f30359": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d4d84fa7fa014c00a310fff00b0120dc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "b391e2d3983645518245600c65ecdcf1": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "824a2e05eeff4e119b0da86cdb96db4c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_0f4004fd7d174efca34cc00ce2f6465d",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_6dc4913c0d674908980c33a5ebdb97bc",
-              "IPY_MODEL_e109f032a5804298b5c9663df7a712b6",
-              "IPY_MODEL_14e3daf2ff3a4533b364cc3ec4858919"
-            ]
-          }
-        },
-        "0f4004fd7d174efca34cc00ce2f6465d": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "6dc4913c0d674908980c33a5ebdb97bc": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_4c5fd0bf6cf840cb8c46a80c87e3dc8e",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_690979db324840408944e4c64dd2fb10"
-          }
-        },
-        "e109f032a5804298b5c9663df7a712b6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_fd8777c971294c91843c0e0c0939e89c",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 28881,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 28881,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_f4b2ed43f6fc4053b617111d1bc94917"
-          }
-        },
-        "14e3daf2ff3a4533b364cc3ec4858919": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_810bc9ab86224610a5784fbce9d1c532",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 29696/? [00:00&lt;00:00, 720332.03it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_2a23ba4831a6446798014e182a89b83a"
-          }
-        },
-        "4c5fd0bf6cf840cb8c46a80c87e3dc8e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "690979db324840408944e4c64dd2fb10": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "fd8777c971294c91843c0e0c0939e89c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "f4b2ed43f6fc4053b617111d1bc94917": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "810bc9ab86224610a5784fbce9d1c532": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "2a23ba4831a6446798014e182a89b83a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "cb79290e7b70428a971ec899451bda49": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_8980ce757ebe4c0ead706e7366d939db",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_b8652cb5935341e0bcd1d1e2956a5058",
-              "IPY_MODEL_e6df39b81f43443c8c8a6fca2509152c",
-              "IPY_MODEL_8a397d4d108c471ba6ba51c5d2ed7256"
-            ]
-          }
-        },
-        "8980ce757ebe4c0ead706e7366d939db": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "b8652cb5935341e0bcd1d1e2956a5058": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_a5232c4f9a7e4f14a415d13e4d2181f0",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d580deb89f3448cd8f8be936e5244fbc"
-          }
-        },
-        "e6df39b81f43443c8c8a6fca2509152c": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_d20a3969a28f444baa27909e5268a671",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 1648877,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 1648877,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_0c5c66c8f43f41a9a9722ddae0be786f"
-          }
-        },
-        "8a397d4d108c471ba6ba51c5d2ed7256": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_c296842b3fbf4cd2873bd16e7545d3c1",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 1649664/? [00:00&lt;00:00, 19995411.83it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_a08938df24174f688389313c217085d6"
-          }
-        },
-        "a5232c4f9a7e4f14a415d13e4d2181f0": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "d580deb89f3448cd8f8be936e5244fbc": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d20a3969a28f444baa27909e5268a671": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "0c5c66c8f43f41a9a9722ddae0be786f": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "c296842b3fbf4cd2873bd16e7545d3c1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "a08938df24174f688389313c217085d6": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "bfd333b7d17c476a836ea63926d4a921": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_41ac3a810ec64cccb2ac205e7f848116",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_3a1cc2a9e61d45c58ce8b812d7019981",
-              "IPY_MODEL_3eb8adc9eb9e47709c0c1a4a46f8330a",
-              "IPY_MODEL_f75e59525ee6408ba26cc9f4f093436b"
-            ]
-          }
-        },
-        "41ac3a810ec64cccb2ac205e7f848116": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "3a1cc2a9e61d45c58ce8b812d7019981": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_979c9988e4774b019f0feb51447ee3da",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_8539434a4f5c4d07ab7897e8819a1188"
-          }
-        },
-        "3eb8adc9eb9e47709c0c1a4a46f8330a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_ecea6454ecd244df8bd97aba97f91ca6",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 4542,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 4542,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_52d17584500640a6a952407c90df9718"
-          }
-        },
-        "f75e59525ee6408ba26cc9f4f093436b": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_bc22bae1d9f24e55b70d25432fc9779f",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 5120/? [00:00&lt;00:00, 125619.10it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_2e05dfcea2724a7a8c7211b45a4a3a04"
-          }
-        },
-        "979c9988e4774b019f0feb51447ee3da": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "8539434a4f5c4d07ab7897e8819a1188": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "ecea6454ecd244df8bd97aba97f91ca6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "52d17584500640a6a952407c90df9718": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "bc22bae1d9f24e55b70d25432fc9779f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "2e05dfcea2724a7a8c7211b45a4a3a04": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5w-QlZE9mvdY"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: How to do Cross Validation in Ignite\n",
+    "weight: 7\n",
+    "date: 2021-09-21\n",
+    "downloads: true\n",
+    "sidebar: true\n",
+    "tags:\n",
+    "  - cross validation\n",
+    "--- -->\n",
+    "\n",
+    "#  How to do Cross Validation in Ignite"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5w-QlZE9mvdY"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: How to do Cross Validation in Ignite\n",
-        "weight: 7\n",
-        "date: 2021-09-21\n",
-        "downloads: true\n",
-        "sidebar: true\n",
-        "tags:\n",
-        "  - cross validation\n",
-        "--- -->\n",
-        "\n",
-        "#  How to do Cross Validation in Ignite"
-      ]
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vJgTaKWU8Doq"
+   },
+   "source": [
+    "This how-to guide demonstrates how we can do Cross Validation using the k-fold technique with PyTorch-Ignite and save the best results. \n",
+    "\n",
+    "Cross Validation is useful for tuning model parameters or when the available data is insufficient to properly test\n",
+    "\n",
+    "<!--more-->\n",
+    "\n",
+    "In this example, we will be using a [ResNet18](https://pytorch.org/vision/stable/models.html#torchvision.models.resnet18) model on the [MNIST](https://pytorch.org/vision/stable/datasets.html#torchvision.datasets.MNIST) dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
     },
+    "id": "1zevsoVQ4nx7",
+    "outputId": "695da3af-ad44-4080-e19f-1bfe43e765c4"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vJgTaKWU8Doq"
-      },
-      "source": [
-        "This how-to guide demonstrates how we can do Cross Validation using the k-fold technique with PyTorch-Ignite and save the best results. \n",
-        "\n",
-        "Cross Validation is useful for tuning model parameters or when the available data is insufficient to properly test\n",
-        "\n",
-        "<!--more-->\n",
-        "\n",
-        "In this example, we will be using a [ResNet18](https://pytorch.org/vision/stable/models.html#torchvision.models.resnet18) model on the [MNIST](https://pytorch.org/vision/stable/datasets.html#torchvision.datasets.MNIST) dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "1zevsoVQ4nx7",
-        "outputId": "695da3af-ad44-4080-e19f-1bfe43e765c4"
-      },
-      "source": [
-        "!pip install pytorch-ignite"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting pytorch-ignite\n",
-            "  Downloading pytorch_ignite-0.4.6-py3-none-any.whl (232 kB)\n",
-            "\u001b[?25l\r\u001b[K     |█▍                              | 10 kB 26.7 MB/s eta 0:00:01\r\u001b[K     |██▉                             | 20 kB 30.9 MB/s eta 0:00:01\r\u001b[K     |████▎                           | 30 kB 24.5 MB/s eta 0:00:01\r\u001b[K     |█████▋                          | 40 kB 18.8 MB/s eta 0:00:01\r\u001b[K     |███████                         | 51 kB 15.1 MB/s eta 0:00:01\r\u001b[K     |████████▌                       | 61 kB 10.9 MB/s eta 0:00:01\r\u001b[K     |█████████▉                      | 71 kB 11.8 MB/s eta 0:00:01\r\u001b[K     |███████████▎                    | 81 kB 13.1 MB/s eta 0:00:01\r\u001b[K     |████████████▊                   | 92 kB 13.9 MB/s eta 0:00:01\r\u001b[K     |██████████████                  | 102 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |███████████████▌                | 112 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████               | 122 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |██████████████████▎             | 133 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |███████████████████▊            | 143 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████████▏          | 153 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |██████████████████████▌         | 163 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |████████████████████████        | 174 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████▍      | 184 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |██████████████████████████▊     | 194 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████▏   | 204 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |█████████████████████████████▋  | 215 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |███████████████████████████████ | 225 kB 13.3 MB/s eta 0:00:01\r\u001b[K     |████████████████████████████████| 232 kB 13.3 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: torch<2,>=1.3 in /usr/local/lib/python3.7/dist-packages (from pytorch-ignite) (1.9.0+cu102)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch<2,>=1.3->pytorch-ignite) (3.7.4.3)\n",
-            "Installing collected packages: pytorch-ignite\n",
-            "Successfully installed pytorch-ignite-0.4.6\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "L_wmAdFgmvdx"
-      },
-      "source": [
-        "## Basic Setup"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XuCvNglbZ5X-"
-      },
-      "source": [
-        "Besides the usual libraries, we will also use [scikit-learn](https://scikit-learn.org/stable/) library, that features many learning algorithms. Here, we are going to use the [KFold class](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "lMphyBmmmvdw",
-        "pycharm": {
-          "is_executing": false
-        }
-      },
-      "source": [
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "from torch.utils.data import DataLoader, SubsetRandomSampler, ConcatDataset\n",
-        "from torchvision.datasets import MNIST\n",
-        "from torchvision.models import resnet18\n",
-        "from torchvision.transforms import Compose, Normalize, ToTensor\n",
-        "\n",
-        "from sklearn.model_selection import KFold\n",
-        "import numpy as np\n",
-        "\n",
-        "from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator\n",
-        "from ignite.metrics import Accuracy, Loss, RunningAverage"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "eZeKOgKymvdx",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 471,
-          "referenced_widgets": [
-            "2ecac1db4380427ea8f79c687b272485",
-            "af9a6e72e0e7429b9bd1b0b29ac64004",
-            "201226132da544fda85023e02e753bd0",
-            "15f004ed0b0944eb8a5e71ad2b510445",
-            "743a448619e04af8b000f2a48a4edffb",
-            "7d5650b586e64670a7e4a2d2f0a6aa0c",
-            "65c9cc7ae37242a4ba1b418e185dba52",
-            "187efadb840b4fa0bc4d093f5055c14a",
-            "c191b634893c4f8fa9fe178707f30359",
-            "d4d84fa7fa014c00a310fff00b0120dc",
-            "b391e2d3983645518245600c65ecdcf1",
-            "824a2e05eeff4e119b0da86cdb96db4c",
-            "0f4004fd7d174efca34cc00ce2f6465d",
-            "6dc4913c0d674908980c33a5ebdb97bc",
-            "e109f032a5804298b5c9663df7a712b6",
-            "14e3daf2ff3a4533b364cc3ec4858919",
-            "4c5fd0bf6cf840cb8c46a80c87e3dc8e",
-            "690979db324840408944e4c64dd2fb10",
-            "fd8777c971294c91843c0e0c0939e89c",
-            "f4b2ed43f6fc4053b617111d1bc94917",
-            "810bc9ab86224610a5784fbce9d1c532",
-            "2a23ba4831a6446798014e182a89b83a",
-            "cb79290e7b70428a971ec899451bda49",
-            "8980ce757ebe4c0ead706e7366d939db",
-            "b8652cb5935341e0bcd1d1e2956a5058",
-            "e6df39b81f43443c8c8a6fca2509152c",
-            "8a397d4d108c471ba6ba51c5d2ed7256",
-            "a5232c4f9a7e4f14a415d13e4d2181f0",
-            "d580deb89f3448cd8f8be936e5244fbc",
-            "d20a3969a28f444baa27909e5268a671",
-            "0c5c66c8f43f41a9a9722ddae0be786f",
-            "c296842b3fbf4cd2873bd16e7545d3c1",
-            "a08938df24174f688389313c217085d6",
-            "bfd333b7d17c476a836ea63926d4a921",
-            "41ac3a810ec64cccb2ac205e7f848116",
-            "3a1cc2a9e61d45c58ce8b812d7019981",
-            "3eb8adc9eb9e47709c0c1a4a46f8330a",
-            "f75e59525ee6408ba26cc9f4f093436b",
-            "979c9988e4774b019f0feb51447ee3da",
-            "8539434a4f5c4d07ab7897e8819a1188",
-            "ecea6454ecd244df8bd97aba97f91ca6",
-            "52d17584500640a6a952407c90df9718",
-            "bc22bae1d9f24e55b70d25432fc9779f",
-            "2e05dfcea2724a7a8c7211b45a4a3a04"
-          ]
-        },
-        "outputId": "7ddc38ec-724f-43fc-9072-d9b9d6d14da3"
-      },
-      "source": [
-        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-        "\n",
-        "\n",
-        "class Net(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super(Net, self).__init__()\n",
-        "\n",
-        "        self.model = resnet18(num_classes=10)\n",
-        "        self.model.conv1 = nn.Conv2d(\n",
-        "            1, 64, kernel_size=3, padding=1, bias=False\n",
-        "        )\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.model(x)\n",
-        "\n",
-        "\n",
-        "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
-        "\n",
-        "train_dataset = MNIST(download=True, root=\".\", transform=data_transform, train=True)\n",
-        "test_dataset = MNIST(download=True, root=\".\", transform=data_transform, train=False)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "2ecac1db4380427ea8f79c687b272485",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/9912422 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "824a2e05eeff4e119b0da86cdb96db4c",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/28881 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "cb79290e7b70428a971ec899451bda49",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/1648877 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "bfd333b7d17c476a836ea63926d4a921",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/4542 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw\n",
-            "\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/torchvision/datasets/mnist.py:498: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)\n",
-            "  return torch.from_numpy(parsed.astype(m[2], copy=False)).view(*s)\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Oj5__dTI6_Rz"
-      },
-      "source": [
-        "def initialize():\n",
-        "    model = Net().to(device)\n",
-        "    optimizer = torch.optim.RMSprop(model.parameters(), lr=1e-06)\n",
-        "    criterion = nn.CrossEntropyLoss()\n",
-        "\n",
-        "    return model, optimizer, criterion"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_C1H2fxzlaxC"
-      },
-      "source": [
-        "## Training using k-fold"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vyP-U1wWc1iu"
-      },
-      "source": [
-        "To be able to use [`KFold`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html) to train the model, we have to split the data in `k` samples. We will use an [map-style data loader](https://pytorch.org/docs/stable/data.html#map-style-datasets) so then we will be able to access the dataset by its indices. Here, we are using [`SubsetRandomSampler`](https://pytorch.org/docs/stable/data.html#torch.utils.data.SubsetRandomSampler) to sample the data elements randomly from the indices provided by the `KFold`. \n",
-        "\n",
-        "As we can see below, the `SubsetRandomSampler` generates lists of data indices according to the `train_idx` and `val_idx`, values provided by the KFold class. Then, these lists of indices are used to build the training and validation data samples."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "iyrEEGHD9Ie5"
-      },
-      "source": [
-        "def setup_dataflow(dataset, train_idx, val_idx):\n",
-        "    train_sampler = SubsetRandomSampler(train_idx)\n",
-        "    val_sampler = SubsetRandomSampler(val_idx)\n",
-        "\n",
-        "    train_loader = DataLoader(dataset, batch_size=128, sampler=train_sampler)\n",
-        "    val_loader = DataLoader(dataset, batch_size=256, sampler=val_sampler)\n",
-        "\n",
-        "    return train_loader, val_loader"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "92yas8QtMyMG"
-      },
-      "source": [
-        "The training process will run for three epochs. For each of them, we calculate [`Accuracy`](https://pytorch.org/ignite/generated/ignite.metrics.Accuracy.html#accuracy) and average [`Loss`](https://pytorch.org/ignite/generated/ignite.metrics.Loss.html#loss) as metrics. \n",
-        "\n",
-        "At the end of each epoch, we will store these metrics in `train_results` and `val_results` so we can evaluate the training progress later."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "dKihuuH4A-sH"
-      },
-      "source": [
-        "def train_model(train_loader, val_loader):\n",
-        "    max_epochs = 3\n",
-        "\n",
-        "    train_results = []\n",
-        "    val_results = []\n",
-        "\n",
-        "    model, optimizer, criterion = initialize()\n",
-        "\n",
-        "    trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
-        "    evaluator = create_supervised_evaluator(model, metrics={\"Accuracy\": Accuracy(), \"Loss\": Loss(criterion)}, device=device)\n",
-        "\n",
-        "    @trainer.on(Events.EPOCH_COMPLETED)\n",
-        "    def log_training_results(trainer):\n",
-        "        evaluator.run(train_loader)\n",
-        "        metrics = evaluator.state.metrics\n",
-        "        train_results.append(metrics)\n",
-        "        print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['Accuracy']:.2f} Avg loss: {metrics['Loss']:.2f}\")\n",
-        "\n",
-        "\n",
-        "    @trainer.on(Events.EPOCH_COMPLETED)\n",
-        "    def log_validation_results(trainer):\n",
-        "        evaluator.run(val_loader)\n",
-        "        metrics = evaluator.state.metrics\n",
-        "        val_results.append(metrics)\n",
-        "\n",
-        "    trainer.run(train_loader, max_epochs=max_epochs) \n",
-        "\n",
-        "    return train_results, val_results"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "mkgBhkp2FYew"
-      },
-      "source": [
-        "Let's concatenate both the datasets so that we can divide them into folds later."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "LNaEjVsjDJIH"
-      },
-      "source": [
-        "dataset = ConcatDataset([train_dataset, test_dataset])"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_BwiMldlDboR"
-      },
-      "source": [
-        "We will split the dataset into three folds for training and, consequently, three folds for valitation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Wfk9Q7fIDHhI"
-      },
-      "source": [
-        "num_folds = 3\n",
-        "splits = KFold(n_splits=num_folds,shuffle=True,random_state=42)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "706JNk1gffbS"
-      },
-      "source": [
-        "We are going to train the model using the folds we created above and we will store the metrics returned by the training method for each of them."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "mophHZUkICKI",
-        "outputId": "994f52c0-6ae6-47ac-bd21-73f7cea16127"
-      },
-      "source": [
-        "results_per_fold = []\n",
-        "\n",
-        "for fold_idx, (train_idx,val_idx) in enumerate(splits.split(np.arange(len(dataset)))):\n",
-        "\n",
-        "    print('Fold {}'.format(fold_idx + 1))\n",
-        "\n",
-        "    train_loader, val_loader = setup_dataflow(dataset, train_idx, val_idx)\n",
-        "    train_results, val_results = train_model(train_loader, val_loader)\n",
-        "    results_per_fold.append([train_results, val_results])"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "metadata": {
-            "tags": null
-          },
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Fold 1\n",
-            "Training Results - Epoch[1] Avg accuracy: 0.73 Avg loss: 1.38\n",
-            "Training Results - Epoch[2] Avg accuracy: 0.84 Avg loss: 0.90\n",
-            "Training Results - Epoch[3] Avg accuracy: 0.89 Avg loss: 0.61\n",
-            "Fold 2\n",
-            "Training Results - Epoch[1] Avg accuracy: 0.74 Avg loss: 1.35\n",
-            "Training Results - Epoch[2] Avg accuracy: 0.85 Avg loss: 0.86\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zv_i4JlklmyD"
-      },
-      "source": [
-        "## Evaluation"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sY6-lqKpfj6R"
-      },
-      "source": [
-        "After training the model, it is possible to evaluate its overall performance. \n",
-        "\n",
-        "For every fold we will get the Accuracy score (`current_fold[1][2][\"Accuracy\"]`) of the validation step (`current_fold[1]`) at epoch 3 (`current_fold[1][2]`), the last of our training. \n",
-        "\n",
-        "In the end, we averaged the validation accuracy score for each fold. This will be our final metric for the model trained using the k-fold technique."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Ah5UoZz-zkoL",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f222917d-176c-4a3c-a56d-bf84bb872a21"
-      },
-      "source": [
-        "acc_sum = 0\n",
-        "for n_fold in range(len(results_per_fold)):\n",
-        "  current_fold = results_per_fold[n_fold]\n",
-        "  print(f\"Validation Results - Fold[{n_fold + 1}] Avg accuracy: {current_fold[1][2]['Accuracy']:.2f} Avg loss: {current_fold[1][2]['Loss']:.2f}\")\n",
-        "  acc_sum += current_fold[1][2]['Accuracy']\n",
-        "\n",
-        "folds_mean = acc_sum/num_folds\n",
-        "print(f\"Model validation average for {num_folds}-folds: {folds_mean :.2f}\")"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Validation Results - Epoch[1] Avg accuracy: 0.89 Avg loss: 0.61\n",
-            "Validation Results - Epoch[2] Avg accuracy: 0.90 Avg loss: 0.57\n",
-            "Validation Results - Epoch[3] Avg accuracy: 0.89 Avg loss: 0.57\n",
-            "Model validation average for 3-folds: 0.89\n"
-          ]
-        }
-      ]
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting pytorch-ignite\n",
+      "  Downloading pytorch_ignite-0.4.6-py3-none-any.whl (232 kB)\n",
+      "\u001b[K     |████████████████████████████████| 232 kB 13.3 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: torch<2,>=1.3 in /usr/local/lib/python3.7/dist-packages (from pytorch-ignite) (1.9.0+cu102)\n",
+      "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from torch<2,>=1.3->pytorch-ignite) (3.7.4.3)\n",
+      "Installing collected packages: pytorch-ignite\n",
+      "Successfully installed pytorch-ignite-0.4.6\n"
+     ]
     }
-  ]
+   ],
+   "source": [
+    "!pip install pytorch-ignite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "L_wmAdFgmvdx"
+   },
+   "source": [
+    "## Basic Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XuCvNglbZ5X-"
+   },
+   "source": [
+    "Besides the usual libraries, we will also use [scikit-learn](https://scikit-learn.org/stable/) library, that features many learning algorithms. Here, we are going to use the [KFold class](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lMphyBmmmvdw",
+    "pycharm": {
+     "is_executing": false
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "from torch.utils.data import DataLoader, SubsetRandomSampler, ConcatDataset\n",
+    "from torchvision.datasets import MNIST\n",
+    "from torchvision.models import resnet18\n",
+    "from torchvision.transforms import Compose, Normalize, ToTensor\n",
+    "\n",
+    "from sklearn.model_selection import KFold\n",
+    "import numpy as np\n",
+    "\n",
+    "from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator\n",
+    "from ignite.metrics import Accuracy, Loss, RunningAverage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 471,
+     "referenced_widgets": [
+      "2ecac1db4380427ea8f79c687b272485",
+      "af9a6e72e0e7429b9bd1b0b29ac64004",
+      "201226132da544fda85023e02e753bd0",
+      "15f004ed0b0944eb8a5e71ad2b510445",
+      "743a448619e04af8b000f2a48a4edffb",
+      "7d5650b586e64670a7e4a2d2f0a6aa0c",
+      "65c9cc7ae37242a4ba1b418e185dba52",
+      "187efadb840b4fa0bc4d093f5055c14a",
+      "c191b634893c4f8fa9fe178707f30359",
+      "d4d84fa7fa014c00a310fff00b0120dc",
+      "b391e2d3983645518245600c65ecdcf1",
+      "824a2e05eeff4e119b0da86cdb96db4c",
+      "0f4004fd7d174efca34cc00ce2f6465d",
+      "6dc4913c0d674908980c33a5ebdb97bc",
+      "e109f032a5804298b5c9663df7a712b6",
+      "14e3daf2ff3a4533b364cc3ec4858919",
+      "4c5fd0bf6cf840cb8c46a80c87e3dc8e",
+      "690979db324840408944e4c64dd2fb10",
+      "fd8777c971294c91843c0e0c0939e89c",
+      "f4b2ed43f6fc4053b617111d1bc94917",
+      "810bc9ab86224610a5784fbce9d1c532",
+      "2a23ba4831a6446798014e182a89b83a",
+      "cb79290e7b70428a971ec899451bda49",
+      "8980ce757ebe4c0ead706e7366d939db",
+      "b8652cb5935341e0bcd1d1e2956a5058",
+      "e6df39b81f43443c8c8a6fca2509152c",
+      "8a397d4d108c471ba6ba51c5d2ed7256",
+      "a5232c4f9a7e4f14a415d13e4d2181f0",
+      "d580deb89f3448cd8f8be936e5244fbc",
+      "d20a3969a28f444baa27909e5268a671",
+      "0c5c66c8f43f41a9a9722ddae0be786f",
+      "c296842b3fbf4cd2873bd16e7545d3c1",
+      "a08938df24174f688389313c217085d6",
+      "bfd333b7d17c476a836ea63926d4a921",
+      "41ac3a810ec64cccb2ac205e7f848116",
+      "3a1cc2a9e61d45c58ce8b812d7019981",
+      "3eb8adc9eb9e47709c0c1a4a46f8330a",
+      "f75e59525ee6408ba26cc9f4f093436b",
+      "979c9988e4774b019f0feb51447ee3da",
+      "8539434a4f5c4d07ab7897e8819a1188",
+      "ecea6454ecd244df8bd97aba97f91ca6",
+      "52d17584500640a6a952407c90df9718",
+      "bc22bae1d9f24e55b70d25432fc9779f",
+      "2e05dfcea2724a7a8c7211b45a4a3a04"
+     ]
+    },
+    "id": "eZeKOgKymvdx",
+    "outputId": "7ddc38ec-724f-43fc-9072-d9b9d6d14da3"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2ecac1db4380427ea8f79c687b272485",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/9912422 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "824a2e05eeff4e119b0da86cdb96db4c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/28881 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cb79290e7b70428a971ec899451bda49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1648877 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bfd333b7d17c476a836ea63926d4a921",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4542 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/torchvision/datasets/mnist.py:498: UserWarning: The given NumPy array is not writeable, and PyTorch does not support non-writeable tensors. This means you can write to the underlying (supposedly non-writeable) NumPy array using the tensor. You may want to copy the array to protect its data or make it writeable before converting it to a tensor. This type of warning will be suppressed for the rest of this program. (Triggered internally at  /pytorch/torch/csrc/utils/tensor_numpy.cpp:180.)\n",
+      "  return torch.from_numpy(parsed.astype(m[2], copy=False)).view(*s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "\n",
+    "        self.model = resnet18(num_classes=10)\n",
+    "        self.model.conv1 = nn.Conv2d(\n",
+    "            1, 64, kernel_size=3, padding=1, bias=False\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "\n",
+    "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
+    "\n",
+    "train_dataset = MNIST(download=True, root=\".\", transform=data_transform, train=True)\n",
+    "test_dataset = MNIST(download=True, root=\".\", transform=data_transform, train=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Oj5__dTI6_Rz"
+   },
+   "outputs": [],
+   "source": [
+    "def initialize():\n",
+    "    model = Net().to(device)\n",
+    "    optimizer = torch.optim.RMSprop(model.parameters(), lr=1e-06)\n",
+    "    criterion = nn.CrossEntropyLoss()\n",
+    "\n",
+    "    return model, optimizer, criterion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_C1H2fxzlaxC"
+   },
+   "source": [
+    "## Training using k-fold"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vyP-U1wWc1iu"
+   },
+   "source": [
+    "To be able to use [`KFold`](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.KFold.html) to train the model, we have to split the data in `k` samples. We will use an [map-style data loader](https://pytorch.org/docs/stable/data.html#map-style-datasets) so then we will be able to access the dataset by its indices. Here, we are using [`SubsetRandomSampler`](https://pytorch.org/docs/stable/data.html#torch.utils.data.SubsetRandomSampler) to sample the data elements randomly from the indices provided by the `KFold`. \n",
+    "\n",
+    "As we can see below, the `SubsetRandomSampler` generates lists of data indices according to the `train_idx` and `val_idx`, values provided by the KFold class. Then, these lists of indices are used to build the training and validation data samples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "iyrEEGHD9Ie5"
+   },
+   "outputs": [],
+   "source": [
+    "def setup_dataflow(dataset, train_idx, val_idx):\n",
+    "    train_sampler = SubsetRandomSampler(train_idx)\n",
+    "    val_sampler = SubsetRandomSampler(val_idx)\n",
+    "\n",
+    "    train_loader = DataLoader(dataset, batch_size=128, sampler=train_sampler)\n",
+    "    val_loader = DataLoader(dataset, batch_size=256, sampler=val_sampler)\n",
+    "\n",
+    "    return train_loader, val_loader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "92yas8QtMyMG"
+   },
+   "source": [
+    "The training process will run for three epochs. For each of them, we calculate [`Accuracy`](https://pytorch.org/ignite/generated/ignite.metrics.Accuracy.html#accuracy) and average [`Loss`](https://pytorch.org/ignite/generated/ignite.metrics.Loss.html#loss) as metrics. \n",
+    "\n",
+    "At the end of each epoch, we will store these metrics in `train_results` and `val_results` so we can evaluate the training progress later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "dKihuuH4A-sH"
+   },
+   "outputs": [],
+   "source": [
+    "def train_model(train_loader, val_loader):\n",
+    "    max_epochs = 3\n",
+    "\n",
+    "    train_results = []\n",
+    "    val_results = []\n",
+    "\n",
+    "    model, optimizer, criterion = initialize()\n",
+    "\n",
+    "    trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
+    "    evaluator = create_supervised_evaluator(model, metrics={\"Accuracy\": Accuracy(), \"Loss\": Loss(criterion)}, device=device)\n",
+    "\n",
+    "    @trainer.on(Events.EPOCH_COMPLETED)\n",
+    "    def log_training_results(trainer):\n",
+    "        evaluator.run(train_loader)\n",
+    "        metrics = evaluator.state.metrics\n",
+    "        train_results.append(metrics)\n",
+    "        print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['Accuracy']:.2f} Avg loss: {metrics['Loss']:.2f}\")\n",
+    "\n",
+    "\n",
+    "    @trainer.on(Events.EPOCH_COMPLETED)\n",
+    "    def log_validation_results(trainer):\n",
+    "        evaluator.run(val_loader)\n",
+    "        metrics = evaluator.state.metrics\n",
+    "        val_results.append(metrics)\n",
+    "\n",
+    "    trainer.run(train_loader, max_epochs=max_epochs) \n",
+    "\n",
+    "    return train_results, val_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mkgBhkp2FYew"
+   },
+   "source": [
+    "Let's concatenate both the datasets so that we can divide them into folds later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LNaEjVsjDJIH"
+   },
+   "outputs": [],
+   "source": [
+    "dataset = ConcatDataset([train_dataset, test_dataset])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_BwiMldlDboR"
+   },
+   "source": [
+    "We will split the dataset into three folds for training and, consequently, three folds for valitation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Wfk9Q7fIDHhI"
+   },
+   "outputs": [],
+   "source": [
+    "num_folds = 3\n",
+    "splits = KFold(n_splits=num_folds,shuffle=True,random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "706JNk1gffbS"
+   },
+   "source": [
+    "We are going to train the model using the folds we created above and we will store the metrics returned by the training method for each of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "mophHZUkICKI",
+    "outputId": "994f52c0-6ae6-47ac-bd21-73f7cea16127"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fold 1\n",
+      "Training Results - Epoch[1] Avg accuracy: 0.73 Avg loss: 1.38\n",
+      "Training Results - Epoch[2] Avg accuracy: 0.84 Avg loss: 0.90\n",
+      "Training Results - Epoch[3] Avg accuracy: 0.89 Avg loss: 0.61\n",
+      "Fold 2\n",
+      "Training Results - Epoch[1] Avg accuracy: 0.74 Avg loss: 1.35\n",
+      "Training Results - Epoch[2] Avg accuracy: 0.85 Avg loss: 0.86\n"
+     ]
+    }
+   ],
+   "source": [
+    "results_per_fold = []\n",
+    "\n",
+    "for fold_idx, (train_idx,val_idx) in enumerate(splits.split(np.arange(len(dataset)))):\n",
+    "\n",
+    "    print('Fold {}'.format(fold_idx + 1))\n",
+    "\n",
+    "    train_loader, val_loader = setup_dataflow(dataset, train_idx, val_idx)\n",
+    "    train_results, val_results = train_model(train_loader, val_loader)\n",
+    "    results_per_fold.append([train_results, val_results])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zv_i4JlklmyD"
+   },
+   "source": [
+    "## Evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sY6-lqKpfj6R"
+   },
+   "source": [
+    "After training the model, it is possible to evaluate its overall performance. \n",
+    "\n",
+    "For every fold we will get the Accuracy score (`current_fold[1][2][\"Accuracy\"]`) of the validation step (`current_fold[1]`) at epoch 3 (`current_fold[1][2]`), the last of our training. \n",
+    "\n",
+    "In the end, we averaged the validation accuracy score for each fold. This will be our final metric for the model trained using the k-fold technique."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "Ah5UoZz-zkoL",
+    "outputId": "f222917d-176c-4a3c-a56d-bf84bb872a21"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Results - Epoch[1] Avg accuracy: 0.89 Avg loss: 0.61\n",
+      "Validation Results - Epoch[2] Avg accuracy: 0.90 Avg loss: 0.57\n",
+      "Validation Results - Epoch[3] Avg accuracy: 0.89 Avg loss: 0.57\n",
+      "Model validation average for 3-folds: 0.89\n"
+     ]
+    }
+   ],
+   "source": [
+    "acc_sum = 0\n",
+    "for n_fold in range(len(results_per_fold)):\n",
+    "  current_fold = results_per_fold[n_fold]\n",
+    "  print(f\"Validation Results - Fold[{n_fold + 1}] Avg accuracy: {current_fold[1][2]['Accuracy']:.2f} Avg loss: {current_fold[1][2]['Loss']:.2f}\")\n",
+    "  acc_sum += current_fold[1][2]['Accuracy']\n",
+    "\n",
+    "folds_mean = acc_sum/num_folds\n",
+    "print(f\"Model validation average for {num_folds}-folds: {folds_mean :.2f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "original cross-validation.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "0c5c66c8f43f41a9a9722ddae0be786f": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "0f4004fd7d174efca34cc00ce2f6465d": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "14e3daf2ff3a4533b364cc3ec4858919": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_2a23ba4831a6446798014e182a89b83a",
+      "placeholder": "​",
+      "style": "IPY_MODEL_810bc9ab86224610a5784fbce9d1c532",
+      "value": " 29696/? [00:00&lt;00:00, 720332.03it/s]"
+     }
+    },
+    "15f004ed0b0944eb8a5e71ad2b510445": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_c191b634893c4f8fa9fe178707f30359",
+      "max": 9912422,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_187efadb840b4fa0bc4d093f5055c14a",
+      "value": 9912422
+     }
+    },
+    "187efadb840b4fa0bc4d093f5055c14a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "201226132da544fda85023e02e753bd0": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_65c9cc7ae37242a4ba1b418e185dba52",
+      "placeholder": "​",
+      "style": "IPY_MODEL_7d5650b586e64670a7e4a2d2f0a6aa0c",
+      "value": ""
+     }
+    },
+    "2a23ba4831a6446798014e182a89b83a": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "2e05dfcea2724a7a8c7211b45a4a3a04": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "2ecac1db4380427ea8f79c687b272485": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_201226132da544fda85023e02e753bd0",
+       "IPY_MODEL_15f004ed0b0944eb8a5e71ad2b510445",
+       "IPY_MODEL_743a448619e04af8b000f2a48a4edffb"
+      ],
+      "layout": "IPY_MODEL_af9a6e72e0e7429b9bd1b0b29ac64004"
+     }
+    },
+    "3a1cc2a9e61d45c58ce8b812d7019981": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_8539434a4f5c4d07ab7897e8819a1188",
+      "placeholder": "​",
+      "style": "IPY_MODEL_979c9988e4774b019f0feb51447ee3da",
+      "value": ""
+     }
+    },
+    "3eb8adc9eb9e47709c0c1a4a46f8330a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_52d17584500640a6a952407c90df9718",
+      "max": 4542,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_ecea6454ecd244df8bd97aba97f91ca6",
+      "value": 4542
+     }
+    },
+    "41ac3a810ec64cccb2ac205e7f848116": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "4c5fd0bf6cf840cb8c46a80c87e3dc8e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "52d17584500640a6a952407c90df9718": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "65c9cc7ae37242a4ba1b418e185dba52": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "690979db324840408944e4c64dd2fb10": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "6dc4913c0d674908980c33a5ebdb97bc": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_690979db324840408944e4c64dd2fb10",
+      "placeholder": "​",
+      "style": "IPY_MODEL_4c5fd0bf6cf840cb8c46a80c87e3dc8e",
+      "value": ""
+     }
+    },
+    "743a448619e04af8b000f2a48a4edffb": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_b391e2d3983645518245600c65ecdcf1",
+      "placeholder": "​",
+      "style": "IPY_MODEL_d4d84fa7fa014c00a310fff00b0120dc",
+      "value": " 9913344/? [00:00&lt;00:00, 53561559.59it/s]"
+     }
+    },
+    "7d5650b586e64670a7e4a2d2f0a6aa0c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "810bc9ab86224610a5784fbce9d1c532": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "824a2e05eeff4e119b0da86cdb96db4c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_6dc4913c0d674908980c33a5ebdb97bc",
+       "IPY_MODEL_e109f032a5804298b5c9663df7a712b6",
+       "IPY_MODEL_14e3daf2ff3a4533b364cc3ec4858919"
+      ],
+      "layout": "IPY_MODEL_0f4004fd7d174efca34cc00ce2f6465d"
+     }
+    },
+    "8539434a4f5c4d07ab7897e8819a1188": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8980ce757ebe4c0ead706e7366d939db": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "8a397d4d108c471ba6ba51c5d2ed7256": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_a08938df24174f688389313c217085d6",
+      "placeholder": "​",
+      "style": "IPY_MODEL_c296842b3fbf4cd2873bd16e7545d3c1",
+      "value": " 1649664/? [00:00&lt;00:00, 19995411.83it/s]"
+     }
+    },
+    "979c9988e4774b019f0feb51447ee3da": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "a08938df24174f688389313c217085d6": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "a5232c4f9a7e4f14a415d13e4d2181f0": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "af9a6e72e0e7429b9bd1b0b29ac64004": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b391e2d3983645518245600c65ecdcf1": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b8652cb5935341e0bcd1d1e2956a5058": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d580deb89f3448cd8f8be936e5244fbc",
+      "placeholder": "​",
+      "style": "IPY_MODEL_a5232c4f9a7e4f14a415d13e4d2181f0",
+      "value": ""
+     }
+    },
+    "bc22bae1d9f24e55b70d25432fc9779f": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "bfd333b7d17c476a836ea63926d4a921": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_3a1cc2a9e61d45c58ce8b812d7019981",
+       "IPY_MODEL_3eb8adc9eb9e47709c0c1a4a46f8330a",
+       "IPY_MODEL_f75e59525ee6408ba26cc9f4f093436b"
+      ],
+      "layout": "IPY_MODEL_41ac3a810ec64cccb2ac205e7f848116"
+     }
+    },
+    "c191b634893c4f8fa9fe178707f30359": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "c296842b3fbf4cd2873bd16e7545d3c1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "cb79290e7b70428a971ec899451bda49": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_b8652cb5935341e0bcd1d1e2956a5058",
+       "IPY_MODEL_e6df39b81f43443c8c8a6fca2509152c",
+       "IPY_MODEL_8a397d4d108c471ba6ba51c5d2ed7256"
+      ],
+      "layout": "IPY_MODEL_8980ce757ebe4c0ead706e7366d939db"
+     }
+    },
+    "d20a3969a28f444baa27909e5268a671": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "d4d84fa7fa014c00a310fff00b0120dc": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "d580deb89f3448cd8f8be936e5244fbc": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "e109f032a5804298b5c9663df7a712b6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_f4b2ed43f6fc4053b617111d1bc94917",
+      "max": 28881,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_fd8777c971294c91843c0e0c0939e89c",
+      "value": 28881
+     }
+    },
+    "e6df39b81f43443c8c8a6fca2509152c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_0c5c66c8f43f41a9a9722ddae0be786f",
+      "max": 1648877,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_d20a3969a28f444baa27909e5268a671",
+      "value": 1648877
+     }
+    },
+    "ecea6454ecd244df8bd97aba97f91ca6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "f4b2ed43f6fc4053b617111d1bc94917": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "f75e59525ee6408ba26cc9f4f093436b": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_2e05dfcea2724a7a8c7211b45a4a3a04",
+      "placeholder": "​",
+      "style": "IPY_MODEL_bc22bae1d9f24e55b70d25432fc9779f",
+      "value": " 5120/? [00:00&lt;00:00, 125619.10it/s]"
+     }
+    },
+    "fd8777c971294c91843c0e0c0939e89c": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/how-to-guides/08-custom-events.ipynb
+++ b/how-to-guides/08-custom-events.ipynb
@@ -1,287 +1,287 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    },
-    "colab": {
-      "name": "08-custom-events.ipynb",
-      "provenance": []
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "YQCt0TA0uaNc",
+   "metadata": {
+    "id": "YQCt0TA0uaNc"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: How to create Custom Events based on Forward or Backward Pass\n",
+    "weight: 8\n",
+    "downloads: true\n",
+    "sidebar: true\n",
+    "summary: Learn how to create custom events that depend on the loss calculated, backward pass, optimization step, etc.\n",
+    "tags:\n",
+    "  - custom events\n",
+    "--- -->\n",
+    "# How to create Custom Events based on Forward or Backward Pass"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YQCt0TA0uaNc"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: How to create Custom Events based on Forward or Backward Pass\n",
-        "weight: 8\n",
-        "downloads: true\n",
-        "sidebar: true\n",
-        "summary: Learn how to create custom events that depend on the loss calculated, backward pass, optimization step, etc.\n",
-        "tags:\n",
-        "  - custom events\n",
-        "--- -->\n",
-        "# How to create Custom Events based on Forward or Backward Pass"
-      ],
-      "id": "YQCt0TA0uaNc"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aMOY2iPOuaNk"
-      },
-      "source": [
-        "This guide demonstrates how you can create [custom events](https://pytorch.org/ignite/concepts.html#custom-events) that depend on the loss calculated and backward pass.\n",
-        "\n",
-        "In this example, we will be using a ResNet18 model on the MNIST dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
-      ],
-      "id": "aMOY2iPOuaNk"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "THcUNAgpWMDF"
-      },
-      "source": [
-        "## Basic Setup"
-      ],
-      "id": "THcUNAgpWMDF"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "Y0sJP9iFa1TB"
-      },
-      "source": [
-        "import pandas as pd\n",
-        "\n",
-        "import torch\n",
-        "from torch import nn\n",
-        "from torch.utils.data import DataLoader\n",
-        "from torchvision.datasets import MNIST\n",
-        "from torchvision.models import resnet18\n",
-        "from torchvision.transforms import Compose, Normalize, ToTensor\n",
-        "\n",
-        "from ignite.engine import Engine, EventEnum, Events, create_supervised_evaluator\n",
-        "from ignite.metrics import Accuracy, Loss\n",
-        "from ignite.handlers import Timer\n",
-        "from ignite.contrib.handlers import BasicTimeProfiler, HandlersTimeProfiler"
-      ],
-      "id": "Y0sJP9iFa1TB",
-      "execution_count": 7,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "iK_9cOP6a1TI"
-      },
-      "source": [
-        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-        "\n",
-        "\n",
-        "class Net(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super(Net, self).__init__()\n",
-        "\n",
-        "        self.model = resnet18(num_classes=10)\n",
-        "        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=3, padding=1, bias=False)\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.model(x)\n",
-        "\n",
-        "\n",
-        "model = Net().to(device)\n",
-        "\n",
-        "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
-        "\n",
-        "train_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=True),\n",
-        "    batch_size=128,\n",
-        "    shuffle=True,\n",
-        ")\n",
-        "\n",
-        "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
-        "criterion = nn.CrossEntropyLoss()"
-      ],
-      "id": "iK_9cOP6a1TI",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Q_u0IS8q9IY-"
-      },
-      "source": [
-        "## Create Custom Events\n",
-        "\n",
-        "First let's create a few custom events based on backpropogation. All user-defined custom events should inherit from the base class [`EventEnum`](https://pytorch.org/ignite/generated/ignite.engine.events.EventEnum.html#ignite.engine.events.EventEnum)."
-      ],
-      "id": "Q_u0IS8q9IY-"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TbEoK_H8yIAj"
-      },
-      "source": [
-        "class BackpropEvents(EventEnum):\n",
-        "    BACKWARD_STARTED = 'backward_started'\n",
-        "    BACKWARD_COMPLETED = 'backward_completed'\n",
-        "    OPTIM_STEP_COMPLETED = 'optim_step_completed'"
-      ],
-      "id": "TbEoK_H8yIAj",
-      "execution_count": 27,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9lwr621Y9Lnx"
-      },
-      "source": [
-        "## Create `trainer`\n",
-        "\n",
-        "Then we define the `train_step` function to be applied on all batches. Within this, we use [`fire_event`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.fire_event) to execute all handlers related to a specific event at that point."
-      ],
-      "id": "9lwr621Y9Lnx"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "8aqUFTEdxxvz"
-      },
-      "source": [
-        "def train_step(engine, batch):\n",
-        "    model.train()\n",
-        "    optimizer.zero_grad()\n",
-        "    x, y = batch[0].to(device), batch[1].to(device)\n",
-        "    y_pred = model(x)\n",
-        "    loss = criterion(y_pred, y)\n",
-        "    \n",
-        "    engine.fire_event(BackpropEvents.BACKWARD_STARTED)\n",
-        "    loss.backward()\n",
-        "    engine.fire_event(BackpropEvents.BACKWARD_COMPLETED)\n",
-        "\n",
-        "    optimizer.step()\n",
-        "    engine.fire_event(BackpropEvents.OPTIM_STEP_COMPLETED)\n",
-        "\n",
-        "    return loss.item()\n",
-        "\n",
-        "\n",
-        "trainer = Engine(train_step)"
-      ],
-      "id": "8aqUFTEdxxvz",
-      "execution_count": 28,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "eiLRGHAK9Q12"
-      },
-      "source": [
-        "## Register Custom Events in `trainer`\n",
-        "\n",
-        "Finally, to make sure our events can be fired, we register them in `trainer` using [`register_events`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.register_events)."
-      ],
-      "id": "eiLRGHAK9Q12"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "4byi6J6N9d4K"
-      },
-      "source": [
-        "trainer.register_events(*BackpropEvents)"
-      ],
-      "id": "4byi6J6N9d4K",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WZbJwRUD9e-d"
-      },
-      "source": [
-        "## Attach handlers to Custom Events\n",
-        "\n",
-        "And now we can easily attach handlers to be executed when a particular event like `BACKWARD_COMPLETED` is fired."
-      ],
-      "id": "WZbJwRUD9e-d"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "9Dp6QBfQysOq"
-      },
-      "source": [
-        "@trainer.on(BackpropEvents.BACKWARD_COMPLETED)\n",
-        "def function_before_backprop(engine):\n",
-        "    print(f\"Iter[{engine.state.iteration}] Function fired after backward pass\")"
-      ],
-      "id": "9Dp6QBfQysOq",
-      "execution_count": 29,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XMKXagQk-VLl"
-      },
-      "source": [
-        "And finally you can run the `trainer` for some epochs. "
-      ],
-      "id": "XMKXagQk-VLl"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3G9DV6h767fj"
-      },
-      "source": [
-        "trainer.run(train_loader, max_epochs=3)"
-      ],
-      "id": "3G9DV6h767fj",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "x031SkP2-Lg9"
-      },
-      "source": [
-        "## Additional Links\n",
-        "\n",
-        "You can also checkout the source code of [TBPTT Trainer](https://pytorch.org/ignite/_modules/ignite/contrib/engines/tbptt.html#create_supervised_tbptt_trainer) for a detailed explanation."
-      ],
-      "id": "x031SkP2-Lg9"
+  {
+   "cell_type": "markdown",
+   "id": "aMOY2iPOuaNk",
+   "metadata": {
+    "id": "aMOY2iPOuaNk"
+   },
+   "source": [
+    "This guide demonstrates how you can create [custom events](https://pytorch.org/ignite/concepts.html#custom-events) that depend on the loss calculated and backward pass.\n",
+    "\n",
+    "In this example, we will be using a ResNet18 model on the MNIST dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "THcUNAgpWMDF",
+   "metadata": {
+    "id": "THcUNAgpWMDF"
+   },
+   "source": [
+    "## Basic Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "Y0sJP9iFa1TB",
+   "metadata": {
+    "id": "Y0sJP9iFa1TB",
+    "pycharm": {
+     "is_executing": false
     }
-  ]
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision.datasets import MNIST\n",
+    "from torchvision.models import resnet18\n",
+    "from torchvision.transforms import Compose, Normalize, ToTensor\n",
+    "\n",
+    "from ignite.engine import Engine, EventEnum, Events, create_supervised_evaluator\n",
+    "from ignite.metrics import Accuracy, Loss\n",
+    "from ignite.handlers import Timer\n",
+    "from ignite.contrib.handlers import BasicTimeProfiler, HandlersTimeProfiler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "iK_9cOP6a1TI",
+   "metadata": {
+    "id": "iK_9cOP6a1TI"
+   },
+   "outputs": [],
+   "source": [
+    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "\n",
+    "        self.model = resnet18(num_classes=10)\n",
+    "        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=3, padding=1, bias=False)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "\n",
+    "model = Net().to(device)\n",
+    "\n",
+    "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
+    "\n",
+    "train_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=True),\n",
+    "    batch_size=128,\n",
+    "    shuffle=True,\n",
+    ")\n",
+    "\n",
+    "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
+    "criterion = nn.CrossEntropyLoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Q_u0IS8q9IY-",
+   "metadata": {
+    "id": "Q_u0IS8q9IY-"
+   },
+   "source": [
+    "## Create Custom Events\n",
+    "\n",
+    "First let's create a few custom events based on backpropogation. All user-defined custom events should inherit from the base class [`EventEnum`](https://pytorch.org/ignite/generated/ignite.engine.events.EventEnum.html#ignite.engine.events.EventEnum)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "TbEoK_H8yIAj",
+   "metadata": {
+    "id": "TbEoK_H8yIAj"
+   },
+   "outputs": [],
+   "source": [
+    "class BackpropEvents(EventEnum):\n",
+    "    BACKWARD_STARTED = 'backward_started'\n",
+    "    BACKWARD_COMPLETED = 'backward_completed'\n",
+    "    OPTIM_STEP_COMPLETED = 'optim_step_completed'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9lwr621Y9Lnx",
+   "metadata": {
+    "id": "9lwr621Y9Lnx"
+   },
+   "source": [
+    "## Create `trainer`\n",
+    "\n",
+    "Then we define the `train_step` function to be applied on all batches. Within this, we use [`fire_event`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.fire_event) to execute all handlers related to a specific event at that point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "8aqUFTEdxxvz",
+   "metadata": {
+    "id": "8aqUFTEdxxvz"
+   },
+   "outputs": [],
+   "source": [
+    "def train_step(engine, batch):\n",
+    "    model.train()\n",
+    "    optimizer.zero_grad()\n",
+    "    x, y = batch[0].to(device), batch[1].to(device)\n",
+    "    y_pred = model(x)\n",
+    "    loss = criterion(y_pred, y)\n",
+    "    \n",
+    "    engine.fire_event(BackpropEvents.BACKWARD_STARTED)\n",
+    "    loss.backward()\n",
+    "    engine.fire_event(BackpropEvents.BACKWARD_COMPLETED)\n",
+    "\n",
+    "    optimizer.step()\n",
+    "    engine.fire_event(BackpropEvents.OPTIM_STEP_COMPLETED)\n",
+    "\n",
+    "    return loss.item()\n",
+    "\n",
+    "\n",
+    "trainer = Engine(train_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eiLRGHAK9Q12",
+   "metadata": {
+    "id": "eiLRGHAK9Q12"
+   },
+   "source": [
+    "## Register Custom Events in `trainer`\n",
+    "\n",
+    "Finally, to make sure our events can be fired, we register them in `trainer` using [`register_events`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.register_events)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4byi6J6N9d4K",
+   "metadata": {
+    "id": "4byi6J6N9d4K"
+   },
+   "outputs": [],
+   "source": [
+    "trainer.register_events(*BackpropEvents)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "WZbJwRUD9e-d",
+   "metadata": {
+    "id": "WZbJwRUD9e-d"
+   },
+   "source": [
+    "## Attach handlers to Custom Events\n",
+    "\n",
+    "And now we can easily attach handlers to be executed when a particular event like `BACKWARD_COMPLETED` is fired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "9Dp6QBfQysOq",
+   "metadata": {
+    "id": "9Dp6QBfQysOq"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(BackpropEvents.BACKWARD_COMPLETED)\n",
+    "def function_before_backprop(engine):\n",
+    "    print(f\"Iter[{engine.state.iteration}] Function fired after backward pass\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "XMKXagQk-VLl",
+   "metadata": {
+    "id": "XMKXagQk-VLl"
+   },
+   "source": [
+    "And finally you can run the `trainer` for some epochs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3G9DV6h767fj",
+   "metadata": {
+    "id": "3G9DV6h767fj"
+   },
+   "outputs": [],
+   "source": [
+    "trainer.run(train_loader, max_epochs=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "x031SkP2-Lg9",
+   "metadata": {
+    "id": "x031SkP2-Lg9"
+   },
+   "source": [
+    "## Additional Links\n",
+    "\n",
+    "You can also checkout the source code of [TBPTT Trainer](https://pytorch.org/ignite/_modules/ignite/contrib/engines/tbptt.html#create_supervised_tbptt_trainer) for a detailed explanation."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "name": "08-custom-events.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/how-to-guides/09-switch-data-training.ipynb
+++ b/how-to-guides/09-switch-data-training.ipynb
@@ -1,266 +1,266 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    },
-    "colab": {
-      "name": "switch-data-training.ipynb",
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "OuJ-YDzWCgEI",
+   "metadata": {
+    "id": "OuJ-YDzWCgEI"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: How to switch data provider during training\n",
+    "weight: 9\n",
+    "downloads: true\n",
+    "sidebar: true\n",
+    "summary: Example on how to switch data during training after some number of iterations\n",
+    "tags:\n",
+    "  - custom events\n",
+    "--- -->\n",
+    "\n",
+    "# How to switch data provider during training"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "zi2JOUi1CgEO",
+   "metadata": {
+    "id": "zi2JOUi1CgEO"
+   },
+   "source": [
+    "In this example, we will see how one can easily switch the data provider during the training using\n",
+    "[`set_data()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.set_data). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wJKPRmQZIV_S",
+   "metadata": {
+    "id": "wJKPRmQZIV_S"
+   },
+   "source": [
+    "## Basic Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "QwpM9M-XI23h",
+   "metadata": {
+    "id": "QwpM9M-XI23h"
+   },
+   "source": [
+    "### Required Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "H_UgUurNIb53",
+   "metadata": {
+    "id": "H_UgUurNIb53"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pytorch-ignite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Z2Yo1WSWI6vr",
+   "metadata": {
+    "id": "Z2Yo1WSWI6vr"
+   },
+   "source": [
+    "### Import"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "-2Ai1Ht_HWiB",
+   "metadata": {
+    "id": "-2Ai1Ht_HWiB"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.engine import Engine, Events"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Q9tTpXjmI9R_",
+   "metadata": {
+    "id": "Q9tTpXjmI9R_"
+   },
+   "source": [
+    "### Data Providers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "g7ctwsy3Han_",
+   "metadata": {
+    "id": "g7ctwsy3Han_"
+   },
+   "outputs": [],
+   "source": [
+    "data1 = [1, 2, 3]\n",
+    "data2 = [11, 12, 13]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "S-aQnuihJbZz",
+   "metadata": {
+    "id": "S-aQnuihJbZz"
+   },
+   "source": [
+    "## Create dummy `trainer`\n",
+    "\n",
+    "Let's create a dummy `train_step` which will print the current iteration and batch of data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "2Skq9nmSHnce",
+   "metadata": {
+    "id": "2Skq9nmSHnce"
+   },
+   "outputs": [],
+   "source": [
+    "def train_step(engine, batch):\n",
+    "    print(f\"Iter[{engine.state.iteration}] Current datapoint = \", batch)\n",
+    "\n",
+    "trainer = Engine(train_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "YIBlmaO6JW9c",
+   "metadata": {
+    "id": "YIBlmaO6JW9c"
+   },
+   "source": [
+    "## Attach handler to switch data\n",
+    "\n",
+    "Now we have to decide when to switch the data provider. It can be after an epoch, iteration or something custom. Below, we are going to switch data after some specific iteration. And then we attach a handler to `trainer` that will be executed once after `switch_iteration` and use `set_data()` so that when:\n",
+    "\n",
+    "* iteration <= `switch_iteration`, batch is from `data1`\n",
+    "* iteration > `switch_iteration`, batch is from `data2`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "RaMkWUwnCgEQ",
+   "metadata": {
+    "id": "RaMkWUwnCgEQ"
+   },
+   "outputs": [],
+   "source": [
+    "switch_iteration = 5\n",
+    "\n",
+    "\n",
+    "@trainer.on(Events.ITERATION_COMPLETED(once=switch_iteration))\n",
+    "def switch_dataloader():\n",
+    "    print(\"<------- Switch Data ------->\")\n",
+    "    trainer.set_data(data2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "BvJ2qms6M44n",
+   "metadata": {
+    "id": "BvJ2qms6M44n"
+   },
+   "source": [
+    "And finally we run the `trainer` for some epochs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "8W-WFdZ8HzJU",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "8W-WFdZ8HzJU",
+    "outputId": "7c2c5a36-f657-4d75-8086-ec3fd1fdf10e"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OuJ-YDzWCgEI"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: How to switch data provider during training\n",
-        "weight: 9\n",
-        "downloads: true\n",
-        "sidebar: true\n",
-        "summary: Example on how to switch data during training after some number of iterations\n",
-        "tags:\n",
-        "  - custom events\n",
-        "--- -->\n",
-        "\n",
-        "# How to switch data provider during training"
-      ],
-      "id": "OuJ-YDzWCgEI"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Iter[1] Current datapoint =  1\n",
+      "Iter[2] Current datapoint =  2\n",
+      "Iter[3] Current datapoint =  3\n",
+      "Iter[4] Current datapoint =  1\n",
+      "Iter[5] Current datapoint =  2\n",
+      "<------- Switch Data ------->\n",
+      "Iter[6] Current datapoint =  11\n",
+      "Iter[7] Current datapoint =  12\n",
+      "Iter[8] Current datapoint =  13\n",
+      "Iter[9] Current datapoint =  11\n",
+      "Iter[10] Current datapoint =  12\n",
+      "Iter[11] Current datapoint =  13\n",
+      "Iter[12] Current datapoint =  11\n",
+      "Iter[13] Current datapoint =  12\n",
+      "Iter[14] Current datapoint =  13\n",
+      "Iter[15] Current datapoint =  11\n"
+     ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "zi2JOUi1CgEO"
-      },
-      "source": [
-        "In this example, we will see how one can easily switch the data provider during the training using\n",
-        "[`set_data()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.set_data). "
-      ],
-      "id": "zi2JOUi1CgEO"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wJKPRmQZIV_S"
-      },
-      "source": [
-        "## Basic Setup"
-      ],
-      "id": "wJKPRmQZIV_S"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QwpM9M-XI23h"
-      },
-      "source": [
-        "### Required Dependencies"
-      ],
-      "id": "QwpM9M-XI23h"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "H_UgUurNIb53"
-      },
-      "source": [
-        "!pip install pytorch-ignite"
-      ],
-      "id": "H_UgUurNIb53",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z2Yo1WSWI6vr"
-      },
-      "source": [
-        "### Import"
-      ],
-      "id": "Z2Yo1WSWI6vr"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "-2Ai1Ht_HWiB"
-      },
-      "source": [
-        "from ignite.engine import Engine, Events"
-      ],
-      "id": "-2Ai1Ht_HWiB",
-      "execution_count": 2,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Q9tTpXjmI9R_"
-      },
-      "source": [
-        "### Data Providers"
-      ],
-      "id": "Q9tTpXjmI9R_"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "g7ctwsy3Han_"
-      },
-      "source": [
-        "data1 = [1, 2, 3]\n",
-        "data2 = [11, 12, 13]"
-      ],
-      "id": "g7ctwsy3Han_",
-      "execution_count": 3,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S-aQnuihJbZz"
-      },
-      "source": [
-        "## Create dummy `trainer`\n",
-        "\n",
-        "Let's create a dummy `train_step` which will print the current iteration and batch of data. "
-      ],
-      "id": "S-aQnuihJbZz"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "2Skq9nmSHnce"
-      },
-      "source": [
-        "def train_step(engine, batch):\n",
-        "    print(f\"Iter[{engine.state.iteration}] Current datapoint = \", batch)\n",
-        "\n",
-        "trainer = Engine(train_step)"
-      ],
-      "id": "2Skq9nmSHnce",
-      "execution_count": 17,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YIBlmaO6JW9c"
-      },
-      "source": [
-        "## Attach handler to switch data\n",
-        "\n",
-        "Now we have to decide when to switch the data provider. It can be after an epoch, iteration or something custom. Below, we are going to switch data after some specific iteration. And then we attach a handler to `trainer` that will be executed once after `switch_iteration` and use `set_data()` so that when:\n",
-        "\n",
-        "* iteration <= `switch_iteration`, batch is from `data1`\n",
-        "* iteration > `switch_iteration`, batch is from `data2`"
-      ],
-      "id": "YIBlmaO6JW9c"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "RaMkWUwnCgEQ"
-      },
-      "source": [
-        "switch_iteration = 5\n",
-        "\n",
-        "\n",
-        "@trainer.on(Events.ITERATION_COMPLETED(once=switch_iteration))\n",
-        "def switch_dataloader():\n",
-        "    print(\"<------- Switch Data ------->\")\n",
-        "    trainer.set_data(data2)"
-      ],
-      "id": "RaMkWUwnCgEQ",
-      "execution_count": 18,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BvJ2qms6M44n"
-      },
-      "source": [
-        "And finally we run the `trainer` for some epochs."
-      ],
-      "id": "BvJ2qms6M44n"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "8W-WFdZ8HzJU",
-        "outputId": "7c2c5a36-f657-4d75-8086-ec3fd1fdf10e"
-      },
-      "source": [
-        "trainer.run(data1, max_epochs=5)"
-      ],
-      "id": "8W-WFdZ8HzJU",
-      "execution_count": 19,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Iter[1] Current datapoint =  1\n",
-            "Iter[2] Current datapoint =  2\n",
-            "Iter[3] Current datapoint =  3\n",
-            "Iter[4] Current datapoint =  1\n",
-            "Iter[5] Current datapoint =  2\n",
-            "<------- Switch Data ------->\n",
-            "Iter[6] Current datapoint =  11\n",
-            "Iter[7] Current datapoint =  12\n",
-            "Iter[8] Current datapoint =  13\n",
-            "Iter[9] Current datapoint =  11\n",
-            "Iter[10] Current datapoint =  12\n",
-            "Iter[11] Current datapoint =  13\n",
-            "Iter[12] Current datapoint =  11\n",
-            "Iter[13] Current datapoint =  12\n",
-            "Iter[14] Current datapoint =  13\n",
-            "Iter[15] Current datapoint =  11\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "State:\n",
-              "\titeration: 15\n",
-              "\tepoch: 5\n",
-              "\tepoch_length: 3\n",
-              "\tmax_epochs: 5\n",
-              "\toutput: <class 'NoneType'>\n",
-              "\tbatch: 11\n",
-              "\tmetrics: <class 'dict'>\n",
-              "\tdataloader: <class 'list'>\n",
-              "\tseed: <class 'NoneType'>\n",
-              "\ttimes: <class 'dict'>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 19
-        }
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 15\n",
+       "\tepoch: 5\n",
+       "\tepoch_length: 3\n",
+       "\tmax_epochs: 5\n",
+       "\toutput: <class 'NoneType'>\n",
+       "\tbatch: 11\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'list'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
       ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-  ]
+   ],
+   "source": [
+    "trainer.run(data1, max_epochs=5)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "switch-data-training.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/how-to-guides/10-loggers.ipynb
+++ b/how-to-guides/10-loggers.ipynb
@@ -378,9 +378,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/how-to-guides/11-load-checkpoint.ipynb
+++ b/how-to-guides/11-load-checkpoint.ipynb
@@ -1,1921 +1,1921 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    },
-    "colab": {
-      "name": "11-load-checkpoint.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "accelerator": "GPU",
-    "widgets": {
-      "application/vnd.jupyter.widget-state+json": {
-        "398f231f132040bd955a157a31420fd8": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_92a8e7515cc44682b5f3188928bc4432",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_34b9dbde96e645ad9b63cfa0ebf7e963",
-              "IPY_MODEL_a483d8f2ebd9423eb768193cc8e86500",
-              "IPY_MODEL_bbb008bf6af34695a5467b352069bd78"
-            ]
-          }
-        },
-        "92a8e7515cc44682b5f3188928bc4432": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "34b9dbde96e645ad9b63cfa0ebf7e963": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_fc2abefbf85e4c9281d4273f14ae6f56",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d17d55e5cae54ea98c4b9633b4d7389a"
-          }
-        },
-        "a483d8f2ebd9423eb768193cc8e86500": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_f295a51f7343425094d3e143ac57e4ad",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 9912422,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 9912422,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_abc80904cf914bd09bb9a46a3519729f"
-          }
-        },
-        "bbb008bf6af34695a5467b352069bd78": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_1e700628e1114eb3a0a48c4082b8dcda",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 9913344/? [00:00&lt;00:00, 47885888.37it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_a07ded3b4c7d433797af5d0ade894795"
-          }
-        },
-        "fc2abefbf85e4c9281d4273f14ae6f56": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "d17d55e5cae54ea98c4b9633b4d7389a": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "f295a51f7343425094d3e143ac57e4ad": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "abc80904cf914bd09bb9a46a3519729f": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "1e700628e1114eb3a0a48c4082b8dcda": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "a07ded3b4c7d433797af5d0ade894795": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "ba9350943980407693a5ef5e1bc197e6": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_42945a0bb01b49ca8bbad8d26ed87393",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_d9e20a9af266481eae90669a6cafab8a",
-              "IPY_MODEL_18313a6cdf6d4fb5a4d279b5a1fa0b66",
-              "IPY_MODEL_fa32e60fb8654976bdfa39e1f9fef9f2"
-            ]
-          }
-        },
-        "42945a0bb01b49ca8bbad8d26ed87393": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d9e20a9af266481eae90669a6cafab8a": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_b3421afc79504c3abc5a584f96e249dd",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_780ae812af7b423689b20cea6a97e2d0"
-          }
-        },
-        "18313a6cdf6d4fb5a4d279b5a1fa0b66": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_c504e99fb6304ea682cad2a7968550ac",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 28881,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 28881,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_5b098b70e2384c89a27ca953fad7426c"
-          }
-        },
-        "fa32e60fb8654976bdfa39e1f9fef9f2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_cc9b772ba5f24f83adba7f6fcf6c7b37",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 29696/? [00:00&lt;00:00, 556793.06it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_bf3a53c822ef41d38310f69783c7e654"
-          }
-        },
-        "b3421afc79504c3abc5a584f96e249dd": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "780ae812af7b423689b20cea6a97e2d0": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "c504e99fb6304ea682cad2a7968550ac": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "5b098b70e2384c89a27ca953fad7426c": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "cc9b772ba5f24f83adba7f6fcf6c7b37": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "bf3a53c822ef41d38310f69783c7e654": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "32c888d741654927bed4e5d19bcd5135": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_c381c4a257864d3a9d089831d4e2af77",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_f0dfb9c567c44032b13b8c9f3eb56249",
-              "IPY_MODEL_04a5f1fa341040688142787c82ed3d0e",
-              "IPY_MODEL_db71842c1eb541aca3a21672ffd9a885"
-            ]
-          }
-        },
-        "c381c4a257864d3a9d089831d4e2af77": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "f0dfb9c567c44032b13b8c9f3eb56249": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_64b07ee9421d49f886c596e3c29bf67f",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_555d0d0eddd54d3b8354186e19ef7fd5"
-          }
-        },
-        "04a5f1fa341040688142787c82ed3d0e": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_c5ba9f33158d4ac2935fa0b9798c9abf",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 1648877,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 1648877,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_9d49ba26ac164e2db301a4c6bb780989"
-          }
-        },
-        "db71842c1eb541aca3a21672ffd9a885": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_934069d2be87430cb290f33e2edccddf",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 1649664/? [00:00&lt;00:00, 13858659.37it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_4ec30bee884e4619a4005f42552da91e"
-          }
-        },
-        "64b07ee9421d49f886c596e3c29bf67f": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "555d0d0eddd54d3b8354186e19ef7fd5": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "c5ba9f33158d4ac2935fa0b9798c9abf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "9d49ba26ac164e2db301a4c6bb780989": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "934069d2be87430cb290f33e2edccddf": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "4ec30bee884e4619a4005f42552da91e": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "e5d65ea82c5e4c5d821ef6e5291a60c2": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HBoxModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HBoxView",
-            "_dom_classes": [],
-            "_model_name": "HBoxModel",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "box_style": "",
-            "layout": "IPY_MODEL_dbaa4c09bba5419a999f9b3298bdb7b7",
-            "_model_module": "@jupyter-widgets/controls",
-            "children": [
-              "IPY_MODEL_d774affeb0a84570b4f2c33676e2cfb1",
-              "IPY_MODEL_1643014c044043b098f8bbc162bce0ef",
-              "IPY_MODEL_c28d07f586944d4d86ad025d85d5bdd1"
-            ]
-          }
-        },
-        "dbaa4c09bba5419a999f9b3298bdb7b7": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "d774affeb0a84570b4f2c33676e2cfb1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_0b23f6fd5e0c411eb71e9247c8ac0ee3",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": "",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_d45df2ace14042eeb6e3cb3c7bb3712b"
-          }
-        },
-        "1643014c044043b098f8bbc162bce0ef": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "FloatProgressModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "ProgressView",
-            "style": "IPY_MODEL_5aee963a067842a39070bfc5f80d7492",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "FloatProgressModel",
-            "bar_style": "success",
-            "max": 4542,
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": 4542,
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "orientation": "horizontal",
-            "min": 0,
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_f94e1f10f0164c80a204f526acb7d2ed"
-          }
-        },
-        "c28d07f586944d4d86ad025d85d5bdd1": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "HTMLModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "HTMLView",
-            "style": "IPY_MODEL_5ca081f3a84a4c4daf736b6b02d79059",
-            "_dom_classes": [],
-            "description": "",
-            "_model_name": "HTMLModel",
-            "placeholder": "​",
-            "_view_module": "@jupyter-widgets/controls",
-            "_model_module_version": "1.5.0",
-            "value": " 5120/? [00:00&lt;00:00, 136997.06it/s]",
-            "_view_count": null,
-            "_view_module_version": "1.5.0",
-            "description_tooltip": null,
-            "_model_module": "@jupyter-widgets/controls",
-            "layout": "IPY_MODEL_213bf240b4f548b18154120f61c4ba24"
-          }
-        },
-        "0b23f6fd5e0c411eb71e9247c8ac0ee3": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "d45df2ace14042eeb6e3cb3c7bb3712b": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "5aee963a067842a39070bfc5f80d7492": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "ProgressStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "ProgressStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "bar_color": null,
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "f94e1f10f0164c80a204f526acb7d2ed": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        },
-        "5ca081f3a84a4c4daf736b6b02d79059": {
-          "model_module": "@jupyter-widgets/controls",
-          "model_name": "DescriptionStyleModel",
-          "model_module_version": "1.5.0",
-          "state": {
-            "_view_name": "StyleView",
-            "_model_name": "DescriptionStyleModel",
-            "description_width": "",
-            "_view_module": "@jupyter-widgets/base",
-            "_model_module_version": "1.5.0",
-            "_view_count": null,
-            "_view_module_version": "1.2.0",
-            "_model_module": "@jupyter-widgets/controls"
-          }
-        },
-        "213bf240b4f548b18154120f61c4ba24": {
-          "model_module": "@jupyter-widgets/base",
-          "model_name": "LayoutModel",
-          "model_module_version": "1.2.0",
-          "state": {
-            "_view_name": "LayoutView",
-            "grid_template_rows": null,
-            "right": null,
-            "justify_content": null,
-            "_view_module": "@jupyter-widgets/base",
-            "overflow": null,
-            "_model_module_version": "1.2.0",
-            "_view_count": null,
-            "flex_flow": null,
-            "width": null,
-            "min_width": null,
-            "border": null,
-            "align_items": null,
-            "bottom": null,
-            "_model_module": "@jupyter-widgets/base",
-            "top": null,
-            "grid_column": null,
-            "overflow_y": null,
-            "overflow_x": null,
-            "grid_auto_flow": null,
-            "grid_area": null,
-            "grid_template_columns": null,
-            "flex": null,
-            "_model_name": "LayoutModel",
-            "justify_items": null,
-            "grid_row": null,
-            "max_height": null,
-            "align_content": null,
-            "visibility": null,
-            "align_self": null,
-            "height": null,
-            "min_height": null,
-            "padding": null,
-            "grid_auto_rows": null,
-            "grid_gap": null,
-            "max_width": null,
-            "order": null,
-            "_view_module_version": "1.2.0",
-            "grid_template_areas": null,
-            "object_position": null,
-            "object_fit": null,
-            "grid_auto_columns": null,
-            "margin": null,
-            "display": null,
-            "left": null
-          }
-        }
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "HgljXEAJEcFq",
+   "metadata": {
+    "id": "HgljXEAJEcFq"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: How to load checkpoint and resume training\n",
+    "weight: 11\n",
+    "downloads: true\n",
+    "sidebar: true\n",
+    "summary: This example demonstrates how you can save and load a checkpoint then resume training.\n",
+    "tags:\n",
+    "  - load checkpoint\n",
+    "--- -->\n",
+    "# How to load checkpoint and resume training\n",
+    "\n",
+    "In this example, we will be using a ResNet18 model on the MNIST dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HgljXEAJEcFq"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: How to load checkpoint and resume training\n",
-        "weight: 11\n",
-        "downloads: true\n",
-        "sidebar: true\n",
-        "summary: This example demonstrates how you can save and load a checkpoint then resume training.\n",
-        "tags:\n",
-        "  - load checkpoint\n",
-        "--- -->\n",
-        "# How to load checkpoint and resume training\n",
-        "\n",
-        "In this example, we will be using a ResNet18 model on the MNIST dataset. The base code is the same as used in the [Getting Started Guide](https://pytorch-ignite.ai/tutorials/getting-started/)."
-      ],
-      "id": "HgljXEAJEcFq"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "hQPlnvmfEfir"
-      },
-      "source": [
-        "## Required Dependencies"
-      ],
-      "id": "hQPlnvmfEfir"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3d09Jnzt_qmp"
-      },
-      "source": [
-        "!pip install pytorch-ignite -q"
-      ],
-      "id": "3d09Jnzt_qmp",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DcnSr5sGEcFz"
-      },
-      "source": [
-        "## Basic Setup"
-      ],
-      "id": "DcnSr5sGEcFz"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "pycharm": {
-          "is_executing": false
-        },
-        "id": "Y0sJP9iFa1TB"
-      },
-      "source": [
-        "import torch\n",
-        "from torch import nn\n",
-        "from torch.utils.data import DataLoader\n",
-        "from torchvision.datasets import MNIST\n",
-        "from torchvision.models import resnet18\n",
-        "from torchvision.transforms import Compose, Normalize, ToTensor\n",
-        "\n",
-        "from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator\n",
-        "from ignite.metrics import Accuracy, Loss\n",
-        "from ignite.handlers import Checkpoint, global_step_from_engine"
-      ],
-      "id": "Y0sJP9iFa1TB",
-      "execution_count": 2,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "iK_9cOP6a1TI",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 423,
-          "referenced_widgets": [
-            "398f231f132040bd955a157a31420fd8",
-            "92a8e7515cc44682b5f3188928bc4432",
-            "34b9dbde96e645ad9b63cfa0ebf7e963",
-            "a483d8f2ebd9423eb768193cc8e86500",
-            "bbb008bf6af34695a5467b352069bd78",
-            "fc2abefbf85e4c9281d4273f14ae6f56",
-            "d17d55e5cae54ea98c4b9633b4d7389a",
-            "f295a51f7343425094d3e143ac57e4ad",
-            "abc80904cf914bd09bb9a46a3519729f",
-            "1e700628e1114eb3a0a48c4082b8dcda",
-            "a07ded3b4c7d433797af5d0ade894795",
-            "ba9350943980407693a5ef5e1bc197e6",
-            "42945a0bb01b49ca8bbad8d26ed87393",
-            "d9e20a9af266481eae90669a6cafab8a",
-            "18313a6cdf6d4fb5a4d279b5a1fa0b66",
-            "fa32e60fb8654976bdfa39e1f9fef9f2",
-            "b3421afc79504c3abc5a584f96e249dd",
-            "780ae812af7b423689b20cea6a97e2d0",
-            "c504e99fb6304ea682cad2a7968550ac",
-            "5b098b70e2384c89a27ca953fad7426c",
-            "cc9b772ba5f24f83adba7f6fcf6c7b37",
-            "bf3a53c822ef41d38310f69783c7e654",
-            "32c888d741654927bed4e5d19bcd5135",
-            "c381c4a257864d3a9d089831d4e2af77",
-            "f0dfb9c567c44032b13b8c9f3eb56249",
-            "04a5f1fa341040688142787c82ed3d0e",
-            "db71842c1eb541aca3a21672ffd9a885",
-            "64b07ee9421d49f886c596e3c29bf67f",
-            "555d0d0eddd54d3b8354186e19ef7fd5",
-            "c5ba9f33158d4ac2935fa0b9798c9abf",
-            "9d49ba26ac164e2db301a4c6bb780989",
-            "934069d2be87430cb290f33e2edccddf",
-            "4ec30bee884e4619a4005f42552da91e",
-            "e5d65ea82c5e4c5d821ef6e5291a60c2",
-            "dbaa4c09bba5419a999f9b3298bdb7b7",
-            "d774affeb0a84570b4f2c33676e2cfb1",
-            "1643014c044043b098f8bbc162bce0ef",
-            "c28d07f586944d4d86ad025d85d5bdd1",
-            "0b23f6fd5e0c411eb71e9247c8ac0ee3",
-            "d45df2ace14042eeb6e3cb3c7bb3712b",
-            "5aee963a067842a39070bfc5f80d7492",
-            "f94e1f10f0164c80a204f526acb7d2ed",
-            "5ca081f3a84a4c4daf736b6b02d79059",
-            "213bf240b4f548b18154120f61c4ba24"
-          ]
-        },
-        "outputId": "acd39bc7-c6b4-4872-9ecd-226c79beb341"
-      },
-      "source": [
-        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-        "\n",
-        "\n",
-        "class Net(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super(Net, self).__init__()\n",
-        "\n",
-        "        self.model = resnet18(num_classes=10)\n",
-        "        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=3, padding=1, bias=False)\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.model(x)\n",
-        "\n",
-        "\n",
-        "model = Net().to(device)\n",
-        "\n",
-        "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
-        "\n",
-        "train_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=True),\n",
-        "    batch_size=128,\n",
-        "    shuffle=True,\n",
-        ")\n",
-        "\n",
-        "val_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=False),\n",
-        "    batch_size=256,\n",
-        "    shuffle=False,\n",
-        ")\n",
-        "\n",
-        "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
-        "criterion = nn.CrossEntropyLoss()"
-      ],
-      "id": "iK_9cOP6a1TI",
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "398f231f132040bd955a157a31420fd8",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/9912422 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "ba9350943980407693a5ef5e1bc197e6",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/28881 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "32c888d741654927bed4e5d19bcd5135",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/1648877 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw\n",
-            "\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
-            "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "e5d65ea82c5e4c5d821ef6e5291a60c2",
-              "version_minor": 0,
-              "version_major": 2
-            },
-            "text/plain": [
-              "  0%|          | 0/4542 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw\n",
-            "\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ItoswUK-23St"
-      },
-      "source": [
-        "trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
-        "evaluator = create_supervised_evaluator(\n",
-        "    model, metrics={\"accuracy\": Accuracy(), \"loss\": Loss(criterion)}, device=device\n",
-        ")\n",
-        "\n",
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_validation_results(trainer):\n",
-        "    evaluator.run(val_loader)\n",
-        "    metrics = evaluator.state.metrics\n",
-        "    print(\n",
-        "        f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\"\n",
-        "    )"
-      ],
-      "id": "ItoswUK-23St",
-      "execution_count": 4,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7JRLbhiw903w"
-      },
-      "source": [
-        "## Checkpoint\n",
-        "\n",
-        "We can use [`Checkpoint()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.Checkpoint.html#checkpoint) as shown below to save the latest model after each epoch is completed. `to_save` here also saves the state of the optimizer and `trainer` in case we want to load this checkpoint and resume training."
-      ],
-      "id": "7JRLbhiw903w"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "W6Zd7vKn1LLO",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f88876b4-bc8a-4b6e-e52a-68d36128d09f"
-      },
-      "source": [
-        "to_save = {'model': model, 'optimizer': optimizer, 'trainer': trainer}\n",
-        "checkpoint_dir = \"checkpoints/\"\n",
-        "\n",
-        "checkpoint = Checkpoint(\n",
-        "    to_save,\n",
-        "    checkpoint_dir,\n",
-        "    n_saved=1,\n",
-        "    global_step_transform=global_step_from_engine(trainer),\n",
-        ")  \n",
-        "evaluator.add_event_handler(Events.COMPLETED, checkpoint)"
-      ],
-      "id": "W6Zd7vKn1LLO",
-      "execution_count": 5,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<ignite.engine.events.RemovableEventHandle at 0x7f1a8490c090>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 5
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Aq0qwiZrEcF_"
-      },
-      "source": [
-        "## Start Training\n",
-        "\n",
-        "Finally, we start the engine on the training dataset and run it for 2\n",
-        "epochs:"
-      ],
-      "id": "Aq0qwiZrEcF_"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qnmTh4FeEcGA",
-        "outputId": "422c3928-5c32-477b-a69f-1d391d7a06ef"
-      },
-      "source": [
-        "trainer.run(train_loader, max_epochs=2)"
-      ],
-      "id": "qnmTh4FeEcGA",
-      "execution_count": 6,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Validation Results - Epoch[1] Avg accuracy: 0.96 Avg loss: 0.16\n",
-            "Validation Results - Epoch[2] Avg accuracy: 0.98 Avg loss: 0.07\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "State:\n",
-              "\titeration: 938\n",
-              "\tepoch: 2\n",
-              "\tepoch_length: 469\n",
-              "\tmax_epochs: 2\n",
-              "\toutput: 0.026344267651438713\n",
-              "\tbatch: <class 'list'>\n",
-              "\tmetrics: <class 'dict'>\n",
-              "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
-              "\tseed: <class 'NoneType'>\n",
-              "\ttimes: <class 'dict'>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 6
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Nui9l-60g5Zy"
-      },
-      "source": [
-        "## Load Checkpoint\n",
-        "\n",
-        "Now let's assume, we have reset our model, optimizer and trainer. After instantiating these objects again, we need to resume training from the checkpoint that we have saved."
-      ],
-      "id": "Nui9l-60g5Zy"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_xj4NMjdArYh",
-        "outputId": "f6151d5c-1559-4ccd-f3c8-34c60315b212"
-      },
-      "source": [
-        "!ls checkpoints"
-      ],
-      "id": "_xj4NMjdArYh",
-      "execution_count": 7,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "checkpoint_2.pt\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "GaMgrEYtD6YM"
-      },
-      "source": [
-        "We can use [`load_objects()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.Checkpoint.html#ignite.handlers.checkpoint.Checkpoint.load_objects) to apply the state of our checkpoint to the objects stored in `to_save`."
-      ],
-      "id": "GaMgrEYtD6YM"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ovuakd8yBfa2"
-      },
-      "source": [
-        "checkpoint_fp = checkpoint_dir + \"checkpoint_2.pt\"\n",
-        "checkpoint = torch.load(checkpoint_fp, map_location=device) \n",
-        "Checkpoint.load_objects(to_load=to_save, checkpoint=checkpoint) "
-      ],
-      "id": "ovuakd8yBfa2",
-      "execution_count": 8,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4XqVAePJg-AO"
-      },
-      "source": [
-        "## Resume Training"
-      ],
-      "id": "4XqVAePJg-AO"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "SEuDCH3xhAcz",
-        "outputId": "935d95f7-42d4-4b8c-d43b-9c9ae30cfab2"
-      },
-      "source": [
-        "trainer.run(train_loader, max_epochs=4)"
-      ],
-      "id": "SEuDCH3xhAcz",
-      "execution_count": 9,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Validation Results - Epoch[3] Avg accuracy: 0.99 Avg loss: 0.04\n",
-            "Validation Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.06\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "State:\n",
-              "\titeration: 1876\n",
-              "\tepoch: 4\n",
-              "\tepoch_length: 469\n",
-              "\tmax_epochs: 4\n",
-              "\toutput: 0.0412273071706295\n",
-              "\tbatch: <class 'list'>\n",
-              "\tmetrics: <class 'dict'>\n",
-              "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
-              "\tseed: <class 'NoneType'>\n",
-              "\ttimes: <class 'dict'>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 9
-        }
-      ]
+  {
+   "cell_type": "markdown",
+   "id": "hQPlnvmfEfir",
+   "metadata": {
+    "id": "hQPlnvmfEfir"
+   },
+   "source": [
+    "## Required Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d09Jnzt_qmp",
+   "metadata": {
+    "id": "3d09Jnzt_qmp"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pytorch-ignite -q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DcnSr5sGEcFz",
+   "metadata": {
+    "id": "DcnSr5sGEcFz"
+   },
+   "source": [
+    "## Basic Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "Y0sJP9iFa1TB",
+   "metadata": {
+    "id": "Y0sJP9iFa1TB",
+    "pycharm": {
+     "is_executing": false
     }
-  ]
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision.datasets import MNIST\n",
+    "from torchvision.models import resnet18\n",
+    "from torchvision.transforms import Compose, Normalize, ToTensor\n",
+    "\n",
+    "from ignite.engine import Events, create_supervised_trainer, create_supervised_evaluator\n",
+    "from ignite.metrics import Accuracy, Loss\n",
+    "from ignite.handlers import Checkpoint, global_step_from_engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "iK_9cOP6a1TI",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 423,
+     "referenced_widgets": [
+      "398f231f132040bd955a157a31420fd8",
+      "92a8e7515cc44682b5f3188928bc4432",
+      "34b9dbde96e645ad9b63cfa0ebf7e963",
+      "a483d8f2ebd9423eb768193cc8e86500",
+      "bbb008bf6af34695a5467b352069bd78",
+      "fc2abefbf85e4c9281d4273f14ae6f56",
+      "d17d55e5cae54ea98c4b9633b4d7389a",
+      "f295a51f7343425094d3e143ac57e4ad",
+      "abc80904cf914bd09bb9a46a3519729f",
+      "1e700628e1114eb3a0a48c4082b8dcda",
+      "a07ded3b4c7d433797af5d0ade894795",
+      "ba9350943980407693a5ef5e1bc197e6",
+      "42945a0bb01b49ca8bbad8d26ed87393",
+      "d9e20a9af266481eae90669a6cafab8a",
+      "18313a6cdf6d4fb5a4d279b5a1fa0b66",
+      "fa32e60fb8654976bdfa39e1f9fef9f2",
+      "b3421afc79504c3abc5a584f96e249dd",
+      "780ae812af7b423689b20cea6a97e2d0",
+      "c504e99fb6304ea682cad2a7968550ac",
+      "5b098b70e2384c89a27ca953fad7426c",
+      "cc9b772ba5f24f83adba7f6fcf6c7b37",
+      "bf3a53c822ef41d38310f69783c7e654",
+      "32c888d741654927bed4e5d19bcd5135",
+      "c381c4a257864d3a9d089831d4e2af77",
+      "f0dfb9c567c44032b13b8c9f3eb56249",
+      "04a5f1fa341040688142787c82ed3d0e",
+      "db71842c1eb541aca3a21672ffd9a885",
+      "64b07ee9421d49f886c596e3c29bf67f",
+      "555d0d0eddd54d3b8354186e19ef7fd5",
+      "c5ba9f33158d4ac2935fa0b9798c9abf",
+      "9d49ba26ac164e2db301a4c6bb780989",
+      "934069d2be87430cb290f33e2edccddf",
+      "4ec30bee884e4619a4005f42552da91e",
+      "e5d65ea82c5e4c5d821ef6e5291a60c2",
+      "dbaa4c09bba5419a999f9b3298bdb7b7",
+      "d774affeb0a84570b4f2c33676e2cfb1",
+      "1643014c044043b098f8bbc162bce0ef",
+      "c28d07f586944d4d86ad025d85d5bdd1",
+      "0b23f6fd5e0c411eb71e9247c8ac0ee3",
+      "d45df2ace14042eeb6e3cb3c7bb3712b",
+      "5aee963a067842a39070bfc5f80d7492",
+      "f94e1f10f0164c80a204f526acb7d2ed",
+      "5ca081f3a84a4c4daf736b6b02d79059",
+      "213bf240b4f548b18154120f61c4ba24"
+     ]
+    },
+    "id": "iK_9cOP6a1TI",
+    "outputId": "acd39bc7-c6b4-4872-9ecd-226c79beb341"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ./MNIST/raw/train-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "398f231f132040bd955a157a31420fd8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/9912422 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to ./MNIST/raw/train-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba9350943980407693a5ef5e1bc197e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/28881 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/train-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz to ./MNIST/raw/t10k-images-idx3-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "32c888d741654927bed4e5d19bcd5135",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1648877 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-images-idx3-ubyte.gz to ./MNIST/raw\n",
+      "\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz\n",
+      "Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to ./MNIST/raw/t10k-labels-idx1-ubyte.gz\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e5d65ea82c5e4c5d821ef6e5291a60c2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/4542 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting ./MNIST/raw/t10k-labels-idx1-ubyte.gz to ./MNIST/raw\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "\n",
+    "        self.model = resnet18(num_classes=10)\n",
+    "        self.model.conv1 = nn.Conv2d(1, 64, kernel_size=3, padding=1, bias=False)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "\n",
+    "model = Net().to(device)\n",
+    "\n",
+    "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
+    "\n",
+    "train_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=True),\n",
+    "    batch_size=128,\n",
+    "    shuffle=True,\n",
+    ")\n",
+    "\n",
+    "val_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=False),\n",
+    "    batch_size=256,\n",
+    "    shuffle=False,\n",
+    ")\n",
+    "\n",
+    "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
+    "criterion = nn.CrossEntropyLoss()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ItoswUK-23St",
+   "metadata": {
+    "id": "ItoswUK-23St"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = create_supervised_trainer(model, optimizer, criterion, device=device)\n",
+    "evaluator = create_supervised_evaluator(\n",
+    "    model, metrics={\"accuracy\": Accuracy(), \"loss\": Loss(criterion)}, device=device\n",
+    ")\n",
+    "\n",
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_validation_results(trainer):\n",
+    "    evaluator.run(val_loader)\n",
+    "    metrics = evaluator.state.metrics\n",
+    "    print(\n",
+    "        f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7JRLbhiw903w",
+   "metadata": {
+    "id": "7JRLbhiw903w"
+   },
+   "source": [
+    "## Checkpoint\n",
+    "\n",
+    "We can use [`Checkpoint()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.Checkpoint.html#checkpoint) as shown below to save the latest model after each epoch is completed. `to_save` here also saves the state of the optimizer and `trainer` in case we want to load this checkpoint and resume training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "W6Zd7vKn1LLO",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "W6Zd7vKn1LLO",
+    "outputId": "f88876b4-bc8a-4b6e-e52a-68d36128d09f"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ignite.engine.events.RemovableEventHandle at 0x7f1a8490c090>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "to_save = {'model': model, 'optimizer': optimizer, 'trainer': trainer}\n",
+    "checkpoint_dir = \"checkpoints/\"\n",
+    "\n",
+    "checkpoint = Checkpoint(\n",
+    "    to_save,\n",
+    "    checkpoint_dir,\n",
+    "    n_saved=1,\n",
+    "    global_step_transform=global_step_from_engine(trainer),\n",
+    ")  \n",
+    "evaluator.add_event_handler(Events.COMPLETED, checkpoint)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Aq0qwiZrEcF_",
+   "metadata": {
+    "id": "Aq0qwiZrEcF_"
+   },
+   "source": [
+    "## Start Training\n",
+    "\n",
+    "Finally, we start the engine on the training dataset and run it for 2\n",
+    "epochs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "qnmTh4FeEcGA",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qnmTh4FeEcGA",
+    "outputId": "422c3928-5c32-477b-a69f-1d391d7a06ef"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Results - Epoch[1] Avg accuracy: 0.96 Avg loss: 0.16\n",
+      "Validation Results - Epoch[2] Avg accuracy: 0.98 Avg loss: 0.07\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 938\n",
+       "\tepoch: 2\n",
+       "\tepoch_length: 469\n",
+       "\tmax_epochs: 2\n",
+       "\toutput: 0.026344267651438713\n",
+       "\tbatch: <class 'list'>\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.run(train_loader, max_epochs=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Nui9l-60g5Zy",
+   "metadata": {
+    "id": "Nui9l-60g5Zy"
+   },
+   "source": [
+    "## Load Checkpoint\n",
+    "\n",
+    "Now let's assume, we have reset our model, optimizer and trainer. After instantiating these objects again, we need to resume training from the checkpoint that we have saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "_xj4NMjdArYh",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_xj4NMjdArYh",
+    "outputId": "f6151d5c-1559-4ccd-f3c8-34c60315b212"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "checkpoint_2.pt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls checkpoints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "GaMgrEYtD6YM",
+   "metadata": {
+    "id": "GaMgrEYtD6YM"
+   },
+   "source": [
+    "We can use [`load_objects()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.Checkpoint.html#ignite.handlers.checkpoint.Checkpoint.load_objects) to apply the state of our checkpoint to the objects stored in `to_save`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ovuakd8yBfa2",
+   "metadata": {
+    "id": "ovuakd8yBfa2"
+   },
+   "outputs": [],
+   "source": [
+    "checkpoint_fp = checkpoint_dir + \"checkpoint_2.pt\"\n",
+    "checkpoint = torch.load(checkpoint_fp, map_location=device) \n",
+    "Checkpoint.load_objects(to_load=to_save, checkpoint=checkpoint) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4XqVAePJg-AO",
+   "metadata": {
+    "id": "4XqVAePJg-AO"
+   },
+   "source": [
+    "## Resume Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "SEuDCH3xhAcz",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "SEuDCH3xhAcz",
+    "outputId": "935d95f7-42d4-4b8c-d43b-9c9ae30cfab2"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation Results - Epoch[3] Avg accuracy: 0.99 Avg loss: 0.04\n",
+      "Validation Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.06\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 1876\n",
+       "\tepoch: 4\n",
+       "\tepoch_length: 469\n",
+       "\tmax_epochs: 4\n",
+       "\toutput: 0.0412273071706295\n",
+       "\tbatch: <class 'list'>\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.run(train_loader, max_epochs=4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "11-load-checkpoint.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "04a5f1fa341040688142787c82ed3d0e": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_9d49ba26ac164e2db301a4c6bb780989",
+      "max": 1648877,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_c5ba9f33158d4ac2935fa0b9798c9abf",
+      "value": 1648877
+     }
+    },
+    "0b23f6fd5e0c411eb71e9247c8ac0ee3": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "1643014c044043b098f8bbc162bce0ef": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_f94e1f10f0164c80a204f526acb7d2ed",
+      "max": 4542,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_5aee963a067842a39070bfc5f80d7492",
+      "value": 4542
+     }
+    },
+    "18313a6cdf6d4fb5a4d279b5a1fa0b66": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_5b098b70e2384c89a27ca953fad7426c",
+      "max": 28881,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_c504e99fb6304ea682cad2a7968550ac",
+      "value": 28881
+     }
+    },
+    "1e700628e1114eb3a0a48c4082b8dcda": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "213bf240b4f548b18154120f61c4ba24": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "32c888d741654927bed4e5d19bcd5135": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_f0dfb9c567c44032b13b8c9f3eb56249",
+       "IPY_MODEL_04a5f1fa341040688142787c82ed3d0e",
+       "IPY_MODEL_db71842c1eb541aca3a21672ffd9a885"
+      ],
+      "layout": "IPY_MODEL_c381c4a257864d3a9d089831d4e2af77"
+     }
+    },
+    "34b9dbde96e645ad9b63cfa0ebf7e963": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d17d55e5cae54ea98c4b9633b4d7389a",
+      "placeholder": "​",
+      "style": "IPY_MODEL_fc2abefbf85e4c9281d4273f14ae6f56",
+      "value": ""
+     }
+    },
+    "398f231f132040bd955a157a31420fd8": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_34b9dbde96e645ad9b63cfa0ebf7e963",
+       "IPY_MODEL_a483d8f2ebd9423eb768193cc8e86500",
+       "IPY_MODEL_bbb008bf6af34695a5467b352069bd78"
+      ],
+      "layout": "IPY_MODEL_92a8e7515cc44682b5f3188928bc4432"
+     }
+    },
+    "42945a0bb01b49ca8bbad8d26ed87393": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "4ec30bee884e4619a4005f42552da91e": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "555d0d0eddd54d3b8354186e19ef7fd5": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "5aee963a067842a39070bfc5f80d7492": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "5b098b70e2384c89a27ca953fad7426c": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "5ca081f3a84a4c4daf736b6b02d79059": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "64b07ee9421d49f886c596e3c29bf67f": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "780ae812af7b423689b20cea6a97e2d0": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "92a8e7515cc44682b5f3188928bc4432": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "934069d2be87430cb290f33e2edccddf": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "9d49ba26ac164e2db301a4c6bb780989": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "a07ded3b4c7d433797af5d0ade894795": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "a483d8f2ebd9423eb768193cc8e86500": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "FloatProgressModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "FloatProgressModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "ProgressView",
+      "bar_style": "success",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_abc80904cf914bd09bb9a46a3519729f",
+      "max": 9912422,
+      "min": 0,
+      "orientation": "horizontal",
+      "style": "IPY_MODEL_f295a51f7343425094d3e143ac57e4ad",
+      "value": 9912422
+     }
+    },
+    "abc80904cf914bd09bb9a46a3519729f": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "b3421afc79504c3abc5a584f96e249dd": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "ba9350943980407693a5ef5e1bc197e6": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_d9e20a9af266481eae90669a6cafab8a",
+       "IPY_MODEL_18313a6cdf6d4fb5a4d279b5a1fa0b66",
+       "IPY_MODEL_fa32e60fb8654976bdfa39e1f9fef9f2"
+      ],
+      "layout": "IPY_MODEL_42945a0bb01b49ca8bbad8d26ed87393"
+     }
+    },
+    "bbb008bf6af34695a5467b352069bd78": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_a07ded3b4c7d433797af5d0ade894795",
+      "placeholder": "​",
+      "style": "IPY_MODEL_1e700628e1114eb3a0a48c4082b8dcda",
+      "value": " 9913344/? [00:00&lt;00:00, 47885888.37it/s]"
+     }
+    },
+    "bf3a53c822ef41d38310f69783c7e654": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "c28d07f586944d4d86ad025d85d5bdd1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_213bf240b4f548b18154120f61c4ba24",
+      "placeholder": "​",
+      "style": "IPY_MODEL_5ca081f3a84a4c4daf736b6b02d79059",
+      "value": " 5120/? [00:00&lt;00:00, 136997.06it/s]"
+     }
+    },
+    "c381c4a257864d3a9d089831d4e2af77": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "c504e99fb6304ea682cad2a7968550ac": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "c5ba9f33158d4ac2935fa0b9798c9abf": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "cc9b772ba5f24f83adba7f6fcf6c7b37": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    },
+    "d17d55e5cae54ea98c4b9633b4d7389a": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "d45df2ace14042eeb6e3cb3c7bb3712b": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "d774affeb0a84570b4f2c33676e2cfb1": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_d45df2ace14042eeb6e3cb3c7bb3712b",
+      "placeholder": "​",
+      "style": "IPY_MODEL_0b23f6fd5e0c411eb71e9247c8ac0ee3",
+      "value": ""
+     }
+    },
+    "d9e20a9af266481eae90669a6cafab8a": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_780ae812af7b423689b20cea6a97e2d0",
+      "placeholder": "​",
+      "style": "IPY_MODEL_b3421afc79504c3abc5a584f96e249dd",
+      "value": ""
+     }
+    },
+    "db71842c1eb541aca3a21672ffd9a885": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_4ec30bee884e4619a4005f42552da91e",
+      "placeholder": "​",
+      "style": "IPY_MODEL_934069d2be87430cb290f33e2edccddf",
+      "value": " 1649664/? [00:00&lt;00:00, 13858659.37it/s]"
+     }
+    },
+    "dbaa4c09bba5419a999f9b3298bdb7b7": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "e5d65ea82c5e4c5d821ef6e5291a60c2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HBoxModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HBoxModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HBoxView",
+      "box_style": "",
+      "children": [
+       "IPY_MODEL_d774affeb0a84570b4f2c33676e2cfb1",
+       "IPY_MODEL_1643014c044043b098f8bbc162bce0ef",
+       "IPY_MODEL_c28d07f586944d4d86ad025d85d5bdd1"
+      ],
+      "layout": "IPY_MODEL_dbaa4c09bba5419a999f9b3298bdb7b7"
+     }
+    },
+    "f0dfb9c567c44032b13b8c9f3eb56249": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_555d0d0eddd54d3b8354186e19ef7fd5",
+      "placeholder": "​",
+      "style": "IPY_MODEL_64b07ee9421d49f886c596e3c29bf67f",
+      "value": ""
+     }
+    },
+    "f295a51f7343425094d3e143ac57e4ad": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "ProgressStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "ProgressStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "bar_color": null,
+      "description_width": ""
+     }
+    },
+    "f94e1f10f0164c80a204f526acb7d2ed": {
+     "model_module": "@jupyter-widgets/base",
+     "model_module_version": "1.2.0",
+     "model_name": "LayoutModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/base",
+      "_model_module_version": "1.2.0",
+      "_model_name": "LayoutModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "LayoutView",
+      "align_content": null,
+      "align_items": null,
+      "align_self": null,
+      "border": null,
+      "bottom": null,
+      "display": null,
+      "flex": null,
+      "flex_flow": null,
+      "grid_area": null,
+      "grid_auto_columns": null,
+      "grid_auto_flow": null,
+      "grid_auto_rows": null,
+      "grid_column": null,
+      "grid_gap": null,
+      "grid_row": null,
+      "grid_template_areas": null,
+      "grid_template_columns": null,
+      "grid_template_rows": null,
+      "height": null,
+      "justify_content": null,
+      "justify_items": null,
+      "left": null,
+      "margin": null,
+      "max_height": null,
+      "max_width": null,
+      "min_height": null,
+      "min_width": null,
+      "object_fit": null,
+      "object_position": null,
+      "order": null,
+      "overflow": null,
+      "overflow_x": null,
+      "overflow_y": null,
+      "padding": null,
+      "right": null,
+      "top": null,
+      "visibility": null,
+      "width": null
+     }
+    },
+    "fa32e60fb8654976bdfa39e1f9fef9f2": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "HTMLModel",
+     "state": {
+      "_dom_classes": [],
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "HTMLModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/controls",
+      "_view_module_version": "1.5.0",
+      "_view_name": "HTMLView",
+      "description": "",
+      "description_tooltip": null,
+      "layout": "IPY_MODEL_bf3a53c822ef41d38310f69783c7e654",
+      "placeholder": "​",
+      "style": "IPY_MODEL_cc9b772ba5f24f83adba7f6fcf6c7b37",
+      "value": " 29696/? [00:00&lt;00:00, 556793.06it/s]"
+     }
+    },
+    "fc2abefbf85e4c9281d4273f14ae6f56": {
+     "model_module": "@jupyter-widgets/controls",
+     "model_module_version": "1.5.0",
+     "model_name": "DescriptionStyleModel",
+     "state": {
+      "_model_module": "@jupyter-widgets/controls",
+      "_model_module_version": "1.5.0",
+      "_model_name": "DescriptionStyleModel",
+      "_view_count": null,
+      "_view_module": "@jupyter-widgets/base",
+      "_view_module_version": "1.2.0",
+      "_view_name": "StyleView",
+      "description_width": ""
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/tutorials/advanced/01-collective-communication.ipynb
+++ b/tutorials/advanced/01-collective-communication.ipynb
@@ -1,430 +1,430 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "idist-collective-communication.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.10"
-    },
-    "pycharm": {
-      "stem_cell": {
-        "cell_type": "raw",
-        "metadata": {
-          "collapsed": false
-        },
-        "source": []
-      }
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "5w-QlZE9mvdY"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: Collective Communication with Ignite\n",
+    "weight: 1\n",
+    "date: 2021-10-5\n",
+    "downloads: true\n",
+    "sidebar: true\n",
+    "tags:\n",
+    "  - idist\n",
+    "  - all_gather\n",
+    "  - all_reduce\n",
+    "  - broadcast\n",
+    "  - barrier\n",
+    "--- -->\n",
+    "\n",
+    "# Collective Communication with Ignite"
+   ]
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "5w-QlZE9mvdY"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: Collective Communication with Ignite\n",
-        "weight: 1\n",
-        "date: 2021-10-5\n",
-        "downloads: true\n",
-        "sidebar: true\n",
-        "tags:\n",
-        "  - idist\n",
-        "  - all_gather\n",
-        "  - all_reduce\n",
-        "  - broadcast\n",
-        "  - barrier\n",
-        "--- -->\n",
-        "\n",
-        "# Collective Communication with Ignite"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vJgTaKWU8Doq"
-      },
-      "source": [
-        "In this tutorial, we will see how to use advanced distributed functions like `all_reduce()`, `all_gather()`, `broadcast()` and `barrier()`. We will discuss unique use cases for all of them and represent them visually.\n",
-        "\n",
-        "<!--more-->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Qhiy_ylcn2GD"
-      },
-      "source": [
-        "## Required Dependencies"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "1zevsoVQ4nx7"
-      },
-      "source": [
-        "!pip install pytorch-ignite"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TrvIsRKQn42e"
-      },
-      "source": [
-        "## Imports"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "lMphyBmmmvdw",
-        "pycharm": {
-          "is_executing": false
-        }
-      },
-      "source": [
-        "import torch\n",
-        "\n",
-        "import ignite.distributed as idist"
-      ],
-      "execution_count": 2,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Y2KPTliNC2r9"
-      },
-      "source": [
-        "## All Reduce\n",
-        "\n",
-        "![All Reduce Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/all-reduce.png?raw=1)\n",
-        "\n",
-        "The [`all_reduce()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.all_reduce) method is used to collect specified tensors from each process and make them available on every node then perform a specified operation (sum, product, min, max, etc) on them. Let's spawn 3 processes with ranks 0, 1 and 2 and define a `tensor` on all of them. If we performed `all_reduce` with the operation SUM on `tensor` then `tensor` on all ranks will be gathered, added and stored in `tensor` as shown below:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "GHT6EftPOwUq"
-      },
-      "source": [
-        "def all_reduce_example(local_rank):\n",
-        "    tensor = torch.arange(2, dtype=torch.int64) + 1 + 2 * local_rank\n",
-        "    print(f\"Rank {local_rank}, Initial value: {tensor}\")\n",
-        "\n",
-        "    idist.all_reduce(tensor, op=\"SUM\")\n",
-        "    print(f\"Rank {local_rank}, After performing all_reduce: {tensor}\")"
-      ],
-      "execution_count": 3,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "uz5mYRS76gjm"
-      },
-      "source": [
-        "We can use [idist.spawn](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.spawn) to spawn 3 processes (`nproc_per_node`) and execute the above function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "yCc1OxDg3X38",
-        "outputId": "97640f5c-aae7-45d8-b4de-21b5ff49ce3d"
-      },
-      "source": [
-        "idist.spawn(backend=\"gloo\", fn=all_reduce_example, args=(), nproc_per_node=3)"
-      ],
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Rank 0, Initial value: tensor([1, 2])\n",
-            "Rank 2, Initial value: tensor([5, 6])\n",
-            "Rank 1, Initial value: tensor([3, 4])\n",
-            "Rank 0, After performing all_reduce: tensor([ 9, 12])\n",
-            "Rank 1, After performing all_reduce: tensor([ 9, 12])\n",
-            "Rank 2, After performing all_reduce: tensor([ 9, 12])\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FLntezo0NhQg"
-      },
-      "source": [
-        "Now let's assume a more real world scenario - You need to find the average of all the gradients available on different processes. \n",
-        "\n",
-        "> First, we get the number of GPUs available, with the get_world_size method. Then, for every model parameter, we do the following:\n",
-        ">\n",
-        ">    1. Gather the gradients on each process\n",
-        ">    2. Apply the sum operation on the gradients\n",
-        ">    3. Divide by the world size to average them\n",
-        ">\n",
-        "> Finally, we can go on to update the model parameters using the averaged gradients!\n",
-        ">\n",
-        "> -- <cite>[Distributed Deep Learning 101: Introduction](https://towardsdatascience.com/distributed-deep-learning-101-introduction-ebfc1bcd59d9)</cite>\n",
-        "\n",
-        "You can get the number of GPUs (processes) available using another helper method [`idist.get_world_size()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.get_world_size) and then use `all_reduce()` to collect the gradients and apply the SUM operation."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "0j_ErUWhHpTl"
-      },
-      "source": [
-        "def average_gradients(model):\n",
-        "    num_processes = idist.get_world_size()\n",
-        "    for param in model.parameters():\n",
-        "        idist.all_reduce(param.grad.data, op=\"SUM\")\n",
-        "        param.grad.data = param.grad.data / num_processes"
-      ],
-      "execution_count": 7,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7w9oIcIiC6_4"
-      },
-      "source": [
-        "## All Gather\n",
-        "\n",
-        "![All Gather Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/all-gather.png?raw=1)\n",
-        "\n",
-        "The [`all_gather()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.all_gather) method is used when you just want to collect a tensor, number or string across all participating processes. As a basic example, suppose you have to collect all the different values stored in `num` on all ranks. You can achieve this by using `all_gather` as below:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Q1ZD4jPK5CVm"
-      },
-      "source": [
-        "def all_gather_example(local_rank):\n",
-        "    num = 2.0 * idist.get_rank()\n",
-        "    print(f\"Rank {local_rank}, Initial value: {num}\")\n",
-        "\n",
-        "    all_nums = idist.all_gather(num)\n",
-        "    print(f\"Rank {local_rank}, After performing all_gather: {all_nums}\")"
-      ],
-      "execution_count": 8,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "DyGu-S7I5Uzw",
-        "outputId": "50c9e712-819e-4e6e-ef53-305e27787804"
-      },
-      "source": [
-        "idist.spawn(backend=\"gloo\", fn=all_gather_example, args=(), nproc_per_node=3)"
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Rank 0, Initial value: 0.0\n",
-            "Rank 2, Initial value: 4.0\n",
-            "Rank 1, Initial value: 2.0\n",
-            "Rank 2, After performing all_gather: [0.0, 2.0, 4.0]\n",
-            "Rank 0, After performing all_gather: [0.0, 2.0, 4.0]\n",
-            "Rank 1, After performing all_gather: [0.0, 2.0, 4.0]\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "FdTcvz4pStfD"
-      },
-      "source": [
-        "Now let's assume you need to gather the predicted values which are distributed across all the processes on the main process so you could store them to a file. Here is how you can do it: "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NRvgasbLC8Ne"
-      },
-      "source": [
-        "def write_preds_to_file(predictions, filename):\n",
-        "    prediction_tensor = torch.tensor(predictions)\n",
-        "    prediction_tensor = idist.all_gather(prediction_tensor)\n",
-        "\n",
-        "    if idist.get_rank() == 0:\n",
-        "        torch.save(prediction_tensor, filename)"
-      ],
-      "execution_count": 13,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Ib9PfbieNMw_"
-      },
-      "source": [
-        "**Note:** In the above example, only the main process required the gathered values and not all the processes. This can also be done via the `gather()` method."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0fsu-NybC8t1"
-      },
-      "source": [
-        "## Broadcast\n",
-        "\n",
-        "![Broadcast Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/broadcast.png?raw=1)\n",
-        "\n",
-        "The [`broadcast()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.broadcast) method copies a tensor, float or string from a source process to all the other processes. For example, you need to send a message from rank 0 to all other ranks. You can do this by creating the actual message on rank 0 and a placeholder on all other ranks, then broadcast the message mentioning a source rank. You can also use `safe_mode=True` in case the placeholder is not defined on all ranks. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "TWowyRRw55XM"
-      },
-      "source": [
-        "def broadcast_example(local_rank):\n",
-        "    message = f\"hello from rank {idist.get_rank()}\"\n",
-        "    print(f\"Rank {local_rank}, Initial value: {message}\")\n",
-        "\n",
-        "    message = idist.broadcast(message, src=0)\n",
-        "    print(f\"Rank {local_rank}, After performing broadcast: {message}\")"
-      ],
-      "execution_count": 14,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "SYXfJFBfUYiV",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3d81fbed-4531-4fb3-c671-775d4649653d"
-      },
-      "source": [
-        "idist.spawn(backend=\"gloo\", fn=broadcast_example, args=(), nproc_per_node=3)"
-      ],
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Rank 1, Initial value: hello from rank 1\n",
-            "Rank 2, Initial value: hello from rank 2\n",
-            "Rank 0, Initial value: hello from rank 0\n",
-            "Rank 2, After performing broadcast: hello from rank 0\n",
-            "Rank 0, After performing broadcast: hello from rank 0\n",
-            "Rank 1, After performing broadcast: hello from rank 0\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cVXVi2rcTz9X"
-      },
-      "source": [
-        "For a real world use case, let's assume you need to gather the predicted and actual values from all the processes on rank 0 for computing a metric and avoiding a memory error. You can do do this by first using `all_gather()`, then computing the metric and finally using `broadcast()` to share the result with all processes. `src` below refers to the rank of the source process."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "7aXwKnrTC96T"
-      },
-      "source": [
-        "def compute_metric(prediction_tensor, target_tensor):\n",
-        "\n",
-        "    prediction_tensor = idist.all_gather(prediction_tensor)\n",
-        "    target_tensor = idist.all_gather(target_tensor)\n",
-        "\n",
-        "    result = 0.0\n",
-        "    if idist.get_rank() == 0:\n",
-        "        result = compute_fn(prediction_tensor, target_tensor)\n",
-        "\n",
-        "    result = idist.broadcast(result, src=0)\n",
-        "\n",
-        "    return result"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "p5ma7l5cDIuC"
-      },
-      "source": [
-        "## Barrier\n",
-        "\n",
-        "The [`barrier()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.barrier) method helps synchronize all processes. For example - while downloading data during training, we have to make sure only the main process (`rank = 0`) downloads the datasets to prevent the sub processes (`rank > 0`) from downloading the same file to the same path at the same time. This way all sub processes get a copy of this already downloaded dataset. This is where we can utilize `barrier()` to make the sub processes wait until the main process downloads the datasets. Once that is done, all the subprocesses instantiate the datasets, while the main process waits. Finally, all the processes are synced up."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "XInr0zlhDJl6"
-      },
-      "source": [
-        "def get_datasets(config):\n",
-        "    if idist.get_local_rank() > 0:\n",
-        "        idist.barrier()\n",
-        "\n",
-        "    train_dataset, test_dataset = get_train_test_datasets(config[\"data_path\"])\n",
-        "\n",
-        "    if idist.get_local_rank() == 0:\n",
-        "        idist.barrier()\n",
-        "\n",
-        "    return train_dataset, test_dataset"
-      ],
-      "execution_count": null,
-      "outputs": []
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vJgTaKWU8Doq"
+   },
+   "source": [
+    "In this tutorial, we will see how to use advanced distributed functions like `all_reduce()`, `all_gather()`, `broadcast()` and `barrier()`. We will discuss unique use cases for all of them and represent them visually.\n",
+    "\n",
+    "<!--more-->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Qhiy_ylcn2GD"
+   },
+   "source": [
+    "## Required Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "1zevsoVQ4nx7"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pytorch-ignite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TrvIsRKQn42e"
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "lMphyBmmmvdw",
+    "pycharm": {
+     "is_executing": false
     }
-  ]
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "import ignite.distributed as idist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Y2KPTliNC2r9"
+   },
+   "source": [
+    "## All Reduce\n",
+    "\n",
+    "![All Reduce Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/all-reduce.png?raw=1)\n",
+    "\n",
+    "The [`all_reduce()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.all_reduce) method is used to collect specified tensors from each process and make them available on every node then perform a specified operation (sum, product, min, max, etc) on them. Let's spawn 3 processes with ranks 0, 1 and 2 and define a `tensor` on all of them. If we performed `all_reduce` with the operation SUM on `tensor` then `tensor` on all ranks will be gathered, added and stored in `tensor` as shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "id": "GHT6EftPOwUq"
+   },
+   "outputs": [],
+   "source": [
+    "def all_reduce_example(local_rank):\n",
+    "    tensor = torch.arange(2, dtype=torch.int64) + 1 + 2 * local_rank\n",
+    "    print(f\"Rank {local_rank}, Initial value: {tensor}\")\n",
+    "\n",
+    "    idist.all_reduce(tensor, op=\"SUM\")\n",
+    "    print(f\"Rank {local_rank}, After performing all_reduce: {tensor}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "uz5mYRS76gjm"
+   },
+   "source": [
+    "We can use [idist.spawn](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.spawn) to spawn 3 processes (`nproc_per_node`) and execute the above function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "yCc1OxDg3X38",
+    "outputId": "97640f5c-aae7-45d8-b4de-21b5ff49ce3d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0, Initial value: tensor([1, 2])\n",
+      "Rank 2, Initial value: tensor([5, 6])\n",
+      "Rank 1, Initial value: tensor([3, 4])\n",
+      "Rank 0, After performing all_reduce: tensor([ 9, 12])\n",
+      "Rank 1, After performing all_reduce: tensor([ 9, 12])\n",
+      "Rank 2, After performing all_reduce: tensor([ 9, 12])\n"
+     ]
+    }
+   ],
+   "source": [
+    "idist.spawn(backend=\"gloo\", fn=all_reduce_example, args=(), nproc_per_node=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FLntezo0NhQg"
+   },
+   "source": [
+    "Now let's assume a more real world scenario - You need to find the average of all the gradients available on different processes. \n",
+    "\n",
+    "> First, we get the number of GPUs available, with the get_world_size method. Then, for every model parameter, we do the following:\n",
+    ">\n",
+    ">    1. Gather the gradients on each process\n",
+    ">    2. Apply the sum operation on the gradients\n",
+    ">    3. Divide by the world size to average them\n",
+    ">\n",
+    "> Finally, we can go on to update the model parameters using the averaged gradients!\n",
+    ">\n",
+    "> -- <cite>[Distributed Deep Learning 101: Introduction](https://towardsdatascience.com/distributed-deep-learning-101-introduction-ebfc1bcd59d9)</cite>\n",
+    "\n",
+    "You can get the number of GPUs (processes) available using another helper method [`idist.get_world_size()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.get_world_size) and then use `all_reduce()` to collect the gradients and apply the SUM operation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "0j_ErUWhHpTl"
+   },
+   "outputs": [],
+   "source": [
+    "def average_gradients(model):\n",
+    "    num_processes = idist.get_world_size()\n",
+    "    for param in model.parameters():\n",
+    "        idist.all_reduce(param.grad.data, op=\"SUM\")\n",
+    "        param.grad.data = param.grad.data / num_processes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7w9oIcIiC6_4"
+   },
+   "source": [
+    "## All Gather\n",
+    "\n",
+    "![All Gather Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/all-gather.png?raw=1)\n",
+    "\n",
+    "The [`all_gather()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.all_gather) method is used when you just want to collect a tensor, number or string across all participating processes. As a basic example, suppose you have to collect all the different values stored in `num` on all ranks. You can achieve this by using `all_gather` as below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "Q1ZD4jPK5CVm"
+   },
+   "outputs": [],
+   "source": [
+    "def all_gather_example(local_rank):\n",
+    "    num = 2.0 * idist.get_rank()\n",
+    "    print(f\"Rank {local_rank}, Initial value: {num}\")\n",
+    "\n",
+    "    all_nums = idist.all_gather(num)\n",
+    "    print(f\"Rank {local_rank}, After performing all_gather: {all_nums}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "DyGu-S7I5Uzw",
+    "outputId": "50c9e712-819e-4e6e-ef53-305e27787804"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 0, Initial value: 0.0\n",
+      "Rank 2, Initial value: 4.0\n",
+      "Rank 1, Initial value: 2.0\n",
+      "Rank 2, After performing all_gather: [0.0, 2.0, 4.0]\n",
+      "Rank 0, After performing all_gather: [0.0, 2.0, 4.0]\n",
+      "Rank 1, After performing all_gather: [0.0, 2.0, 4.0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "idist.spawn(backend=\"gloo\", fn=all_gather_example, args=(), nproc_per_node=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "FdTcvz4pStfD"
+   },
+   "source": [
+    "Now let's assume you need to gather the predicted values which are distributed across all the processes on the main process so you could store them to a file. Here is how you can do it: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "id": "NRvgasbLC8Ne"
+   },
+   "outputs": [],
+   "source": [
+    "def write_preds_to_file(predictions, filename):\n",
+    "    prediction_tensor = torch.tensor(predictions)\n",
+    "    prediction_tensor = idist.all_gather(prediction_tensor)\n",
+    "\n",
+    "    if idist.get_rank() == 0:\n",
+    "        torch.save(prediction_tensor, filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Ib9PfbieNMw_"
+   },
+   "source": [
+    "**Note:** In the above example, only the main process required the gathered values and not all the processes. This can also be done via the `gather()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0fsu-NybC8t1"
+   },
+   "source": [
+    "## Broadcast\n",
+    "\n",
+    "![Broadcast Diagram](https://github.com/pytorch-ignite/examples/blob/main/tutorials/assets/broadcast.png?raw=1)\n",
+    "\n",
+    "The [`broadcast()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.broadcast) method copies a tensor, float or string from a source process to all the other processes. For example, you need to send a message from rank 0 to all other ranks. You can do this by creating the actual message on rank 0 and a placeholder on all other ranks, then broadcast the message mentioning a source rank. You can also use `safe_mode=True` in case the placeholder is not defined on all ranks. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "TWowyRRw55XM"
+   },
+   "outputs": [],
+   "source": [
+    "def broadcast_example(local_rank):\n",
+    "    message = f\"hello from rank {idist.get_rank()}\"\n",
+    "    print(f\"Rank {local_rank}, Initial value: {message}\")\n",
+    "\n",
+    "    message = idist.broadcast(message, src=0)\n",
+    "    print(f\"Rank {local_rank}, After performing broadcast: {message}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "SYXfJFBfUYiV",
+    "outputId": "3d81fbed-4531-4fb3-c671-775d4649653d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rank 1, Initial value: hello from rank 1\n",
+      "Rank 2, Initial value: hello from rank 2\n",
+      "Rank 0, Initial value: hello from rank 0\n",
+      "Rank 2, After performing broadcast: hello from rank 0\n",
+      "Rank 0, After performing broadcast: hello from rank 0\n",
+      "Rank 1, After performing broadcast: hello from rank 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "idist.spawn(backend=\"gloo\", fn=broadcast_example, args=(), nproc_per_node=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cVXVi2rcTz9X"
+   },
+   "source": [
+    "For a real world use case, let's assume you need to gather the predicted and actual values from all the processes on rank 0 for computing a metric and avoiding a memory error. You can do do this by first using `all_gather()`, then computing the metric and finally using `broadcast()` to share the result with all processes. `src` below refers to the rank of the source process."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7aXwKnrTC96T"
+   },
+   "outputs": [],
+   "source": [
+    "def compute_metric(prediction_tensor, target_tensor):\n",
+    "\n",
+    "    prediction_tensor = idist.all_gather(prediction_tensor)\n",
+    "    target_tensor = idist.all_gather(target_tensor)\n",
+    "\n",
+    "    result = 0.0\n",
+    "    if idist.get_rank() == 0:\n",
+    "        result = compute_fn(prediction_tensor, target_tensor)\n",
+    "\n",
+    "    result = idist.broadcast(result, src=0)\n",
+    "\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "p5ma7l5cDIuC"
+   },
+   "source": [
+    "## Barrier\n",
+    "\n",
+    "The [`barrier()`](https://pytorch.org/ignite/distributed.html#ignite.distributed.utils.barrier) method helps synchronize all processes. For example - while downloading data during training, we have to make sure only the main process (`rank = 0`) downloads the datasets to prevent the sub processes (`rank > 0`) from downloading the same file to the same path at the same time. This way all sub processes get a copy of this already downloaded dataset. This is where we can utilize `barrier()` to make the sub processes wait until the main process downloads the datasets. Once that is done, all the subprocesses instantiate the datasets, while the main process waits. Finally, all the processes are synced up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XInr0zlhDJl6"
+   },
+   "outputs": [],
+   "source": [
+    "def get_datasets(config):\n",
+    "    if idist.get_local_rank() > 0:\n",
+    "        idist.barrier()\n",
+    "\n",
+    "    train_dataset, test_dataset = get_train_test_datasets(config[\"data_path\"])\n",
+    "\n",
+    "    if idist.get_local_rank() == 0:\n",
+    "        idist.barrier()\n",
+    "\n",
+    "    return train_dataset, test_dataset"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "idist-collective-communication.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/tutorials/beginner/01-getting-started.ipynb
+++ b/tutorials/beginner/01-getting-started.ipynb
@@ -1,791 +1,791 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    },
-    "colab": {
-      "name": "getting-started.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "HgljXEAJEcFq",
+   "metadata": {
+    "id": "HgljXEAJEcFq"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: Getting Started\n",
+    "weight: 1\n",
+    "date: 2021-07-27\n",
+    "downloads: true\n",
+    "tags:\n",
+    "  - PyTorch-Ignite\n",
+    "--- -->\n",
+    "\n",
+    "# Getting Started"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "P9VjKOirEcFu",
+   "metadata": {
+    "id": "P9VjKOirEcFu"
+   },
+   "source": [
+    "Welcome to **PyTorch-Ignite**’s quick start guide that covers the\n",
+    "essentials of getting a project up and running while walking through\n",
+    "basic concepts of Ignite. In just a few lines of code, you can get your\n",
+    "model trained and validated. The complete code can be found at the end\n",
+    "of this guide.\n",
+    "\n",
+    "<!--more-->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1QNvbg3SEcFw",
+   "metadata": {
+    "id": "1QNvbg3SEcFw"
+   },
+   "source": [
+    "## Prerequisites\n",
+    "\n",
+    "This tutorial assumes you are familiar with the:\n",
+    "\n",
+    "1.  Basics of Python and deep learning\n",
+    "2.  Structure of PyTorch code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "XTHzzYyoEcFy",
+   "metadata": {
+    "id": "XTHzzYyoEcFy"
+   },
+   "source": [
+    "## Installation\n",
+    "\n",
+    "From `pip`\n",
+    "\n",
+    "``` shell\n",
+    "pip install pytorch-ignite\n",
+    "```\n",
+    "\n",
+    "From `conda`\n",
+    "\n",
+    "``` shell\n",
+    "conda install ignite -c pytorch\n",
+    "```\n",
+    "\n",
+    "See [here](https://pytorch-ignite.ai/how-to-guides/installation/) for other installation\n",
+    "options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DcnSr5sGEcFz",
+   "metadata": {
+    "id": "DcnSr5sGEcFz"
+   },
+   "source": [
+    "## Code\n",
+    "\n",
+    "Import the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Saizk3heEcFz",
+   "metadata": {
+    "id": "Saizk3heEcFz"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision.datasets import MNIST\n",
+    "from torchvision.models import resnet18\n",
+    "from torchvision.transforms import Compose, Normalize, ToTensor\n",
+    "\n",
+    "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
+    "from ignite.metrics import Accuracy, Loss\n",
+    "from ignite.handlers import ModelCheckpoint\n",
+    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecMYtJF7OvgT",
+   "metadata": {
+    "id": "ecMYtJF7OvgT"
+   },
+   "source": [
+    "Speed things up by setting [device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device) to `cuda` if available else `cpu`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sdjDKcFhOuQn",
+   "metadata": {
+    "id": "sdjDKcFhOuQn"
+   },
+   "outputs": [],
+   "source": [
+    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4r_PUH1yEcF1",
+   "metadata": {
+    "id": "4r_PUH1yEcF1"
+   },
+   "source": [
+    "Define a class of your model or use the predefined ResNet18 model (modified for MNIST) below, instantiate it and move it to device:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dVSVAT0OEcF1",
+   "metadata": {
+    "id": "dVSVAT0OEcF1"
+   },
+   "outputs": [],
+   "source": [
+    "class Net(nn.Module):\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "        \n",
+    "        # Changed the output layer to output 10 classes instead of 1000 classes\n",
+    "        self.model = resnet18(num_classes=10)\n",
+    "\n",
+    "        # Changed the input layer to take grayscale images for MNIST instaed of RGB images\n",
+    "        self.model.conv1 = nn.Conv2d(\n",
+    "            1, 64, kernel_size=3, padding=1, bias=False\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "\n",
+    "model = Net().to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "DDIW2zedEcF3",
+   "metadata": {
+    "id": "DDIW2zedEcF3"
+   },
+   "source": [
+    "Now let us define the training and validation datasets (as\n",
+    "[torch.utils.data.DataLoader](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader))\n",
+    "and store them in `train_loader` and `val_loader` respectively. We have\n",
+    "used the [MNIST](https://pytorch.org/vision/stable/datasets.html#mnist)\n",
+    "dataset for ease of understanding.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "PFNgx_-TEcF4",
+   "metadata": {
+    "id": "PFNgx_-TEcF4"
+   },
+   "outputs": [],
+   "source": [
+    "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
+    "\n",
+    "train_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=True), batch_size=128, shuffle=True\n",
+    ")\n",
+    "\n",
+    "val_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=False), batch_size=256, shuffle=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "VC9BUtWXEcF6",
+   "metadata": {
+    "id": "VC9BUtWXEcF6"
+   },
+   "source": [
+    "Finally, we will specify the optimizer and the loss function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6VkGmtVZEcF7",
+   "metadata": {
+    "id": "6VkGmtVZEcF7"
+   },
+   "outputs": [],
+   "source": [
+    "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
+    "criterion = nn.CrossEntropyLoss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb-ak9gEEcF7",
+   "metadata": {
+    "id": "cb-ak9gEEcF7"
+   },
+   "source": [
+    "And we’re done with setting up the important parts of the project.\n",
+    "PyTorch-Ignite will handle all other boilerplate code as we will see\n",
+    "below. Next we have to define a trainer engine by passing our model,\n",
+    "optimizer and loss function to\n",
+    "[`create_supervised_trainer`](https://pytorch.org/ignite/generated/ignite.engine.create_supervised_trainer.html),\n",
+    "and two evaluator engines by passing Ignite’s out-of-the-box\n",
+    "[metrics](https://pytorch.org/ignite/metrics.html#complete-list-of-metrics)\n",
+    "and the model to\n",
+    "[`create_supervised_evaluator`](https://pytorch.org/ignite/generated/ignite.engine.create_supervised_evaluator.html#create-supervised-evaluator). We have defined separate evaluator engines for training and validation because they will serve different functions as we will see later in this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "NufcPqJaEcF8",
+   "metadata": {
+    "id": "NufcPqJaEcF8"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = create_supervised_trainer(model, optimizer, criterion, device)\n",
+    "\n",
+    "val_metrics = {\n",
+    "    \"accuracy\": Accuracy(),\n",
+    "    \"loss\": Loss(criterion)\n",
+    "}\n",
+    "\n",
+    "train_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
+    "val_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "S7YThetiEcF8",
+   "metadata": {
+    "id": "S7YThetiEcF8"
+   },
+   "source": [
+    "The objects `trainer`, `train_evaluator` and `val_evaluator` are all instances of\n",
+    "[`Engine`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine) - the main component of Ignite, which is essentially an abstraction over\n",
+    "the training or validation loop.\n",
+    "\n",
+    "If you need more control over your training and validation loops, you\n",
+    "can create custom `trainer`, `train_evaluator` and `val_evaluator` objects by wrapping the step\n",
+    "logic in `Engine` :\n",
+    "\n",
+    "```python\n",
+    "def train_step(engine, batch):\n",
+    "    model.train()\n",
+    "    optimizer.zero_grad()\n",
+    "    x, y = batch[0].to(device), batch[1].to(device)\n",
+    "    y_pred = model(x)\n",
+    "    loss = criterion(y_pred, y)\n",
+    "    loss.backward()\n",
+    "    optimizer.step()\n",
+    "    return loss.item()\n",
+    "\n",
+    "trainer = Engine(train_step)\n",
+    "\n",
+    "def validation_step(engine, batch):\n",
+    "    model.eval()\n",
+    "    with torch.no_grad():\n",
+    "        x, y = batch[0].to(device), batch[1].to(device)\n",
+    "        y_pred = model(x)\n",
+    "        return y_pred, y\n",
+    "\n",
+    "train_evaluator = Engine(validation_step)\n",
+    "val_evaluator = Engine(validation_step)\n",
+    "\n",
+    "# Attach metrics to the evaluators\n",
+    "for name, metric in val_metrics.items():\n",
+    "    metric.attach(train_evaluator, name)\n",
+    "\n",
+    "for name, metric in val_metrics.items():\n",
+    "    metric.attach(val_evaluator, name)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Sw90sOK9EcF9",
+   "metadata": {
+    "id": "Sw90sOK9EcF9"
+   },
+   "source": [
+    "We can customize the code further by adding all kinds of event handlers.\n",
+    "`Engine` allows adding handlers on various events that are triggered\n",
+    "during the run. When an event is triggered, attached handlers\n",
+    "(functions) are executed. Thus, for logging purposes we add a function\n",
+    "to be executed at the end of every `log_interval`-th iteration:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "YGm_-loUEcF9",
+   "metadata": {
+    "id": "YGm_-loUEcF9"
+   },
+   "outputs": [],
+   "source": [
+    "# How many batches to wait before logging training status\n",
+    "log_interval = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "V3xpFBI6EcF9",
+   "metadata": {
+    "id": "V3xpFBI6EcF9"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(Events.ITERATION_COMPLETED(every=log_interval))\n",
+    "def log_training_loss(engine):\n",
+    "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "O6uwwXO8EcF-",
+   "metadata": {
+    "id": "O6uwwXO8EcF-"
+   },
+   "source": [
+    "or equivalently without the decorator but attaching the handler function\n",
+    "to the `trainer` via\n",
+    "[`add_event_handler`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.add_event_handler)\n",
+    "\n",
+    "``` python\n",
+    "def log_training_loss(engine):\n",
+    "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")\n",
+    "\n",
+    "trainer.add_event_handler(Events.ITERATION_COMPLETED, log_training_loss)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "quQzbAv6EcF-",
+   "metadata": {
+    "id": "quQzbAv6EcF-"
+   },
+   "source": [
+    "After an epoch ends during training, we can compute the training and\n",
+    "validation metrics by running `train_evaluator` on `train_loader` and `val_evaluator` on\n",
+    "`val_loader` respectively. Hence we will attach two additional handlers to `trainer`\n",
+    "when an epoch completes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eCE552PFEcF_",
+   "metadata": {
+    "id": "eCE552PFEcF_"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_training_results(trainer):\n",
+    "    train_evaluator.run(train_loader)\n",
+    "    metrics = train_evaluator.state.metrics\n",
+    "    print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
+    "\n",
+    "\n",
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_validation_results(trainer):\n",
+    "    val_evaluator.run(val_loader)\n",
+    "    metrics = val_evaluator.state.metrics\n",
+    "    print(f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7JRLbhiw903w",
+   "metadata": {
+    "id": "7JRLbhiw903w"
+   },
+   "source": [
+    "We can use [`ModelCheckpoint()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.ModelCheckpoint.html#modelcheckpoint) as shown below to save the `n_saved` best models determined by a metric (here accuracy) after each epoch is completed. We attach `model_checkpoint` to `val_evaluator` because we want the two models with the highest accuracies on the validation dataset rather than the training dataset. This is why we defined two separate evaluators (`val_evaluator` and `train_evaluator`) before."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "W6Zd7vKn1LLO",
+   "metadata": {
+    "id": "W6Zd7vKn1LLO"
+   },
+   "outputs": [],
+   "source": [
+    "# Score function to return current value of any metric we defined above in val_metrics\n",
+    "def score_function(engine):\n",
+    "    return engine.state.metrics[\"accuracy\"]\n",
+    "\n",
+    "# Checkpoint to store n_saved best models wrt score function\n",
+    "model_checkpoint = ModelCheckpoint(\n",
+    "    \"checkpoint\",\n",
+    "    n_saved=2,\n",
+    "    filename_prefix=\"best\",\n",
+    "    score_function=score_function,\n",
+    "    score_name=\"accuracy\",\n",
+    "    global_step_transform=global_step_from_engine(trainer), # helps fetch the trainer's state\n",
+    ")\n",
+    "  \n",
+    "# Save the model after every epoch of val_evaluator is completed\n",
+    "val_evaluator.add_event_handler(Events.COMPLETED, model_checkpoint, {\"model\": model})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "KAB0QtrgiTLK",
+   "metadata": {
+    "id": "KAB0QtrgiTLK"
+   },
+   "source": [
+    "We will use [`TensorboardLogger()`](https://pytorch.org/ignite/generated/ignite.contrib.handlers.tensorboard_logger.html#ignite.contrib.handlers.tensorboard_logger.TensorboardLogger) to log trainer's loss, and training and validation metrics separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "Rdt6AE6oeh6k",
+   "metadata": {
+    "id": "Rdt6AE6oeh6k"
+   },
+   "outputs": [],
+   "source": [
+    "# Define a Tensorboard logger\n",
+    "tb_logger = TensorboardLogger(log_dir=\"tb-logger\")\n",
+    "\n",
+    "# Attach handler to plot trainer's loss every 100 iterations\n",
+    "tb_logger.attach_output_handler(\n",
+    "    trainer,\n",
+    "    event_name=Events.ITERATION_COMPLETED(every=100),\n",
+    "    tag=\"training\",\n",
+    "    output_transform=lambda loss: {\"batch_loss\": loss},\n",
+    ")\n",
+    "\n",
+    "# Attach handler for plotting both evaluators' metrics after every epoch completes\n",
+    "for tag, evaluator in [(\"training\", train_evaluator), (\"validation\", val_evaluator)]:\n",
+    "    tb_logger.attach_output_handler(\n",
+    "        evaluator,\n",
+    "        event_name=Events.EPOCH_COMPLETED,\n",
+    "        tag=tag,\n",
+    "        metric_names=\"all\",\n",
+    "        global_step_transform=global_step_from_engine(trainer),\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "Aq0qwiZrEcF_",
+   "metadata": {
+    "id": "Aq0qwiZrEcF_"
+   },
+   "source": [
+    "Finally, we start the engine on the training dataset and run it for 5\n",
+    "epochs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "qnmTh4FeEcGA",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "qnmTh4FeEcGA",
+    "outputId": "f444d98f-8f45-44ea-bd82-9cecb6971bbe"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HgljXEAJEcFq"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: Getting Started\n",
-        "weight: 1\n",
-        "date: 2021-07-27\n",
-        "downloads: true\n",
-        "tags:\n",
-        "  - PyTorch-Ignite\n",
-        "--- -->\n",
-        "\n",
-        "# Getting Started"
-      ],
-      "id": "HgljXEAJEcFq"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch[1], Iter[100] Loss: 0.19\n",
+      "Epoch[1], Iter[200] Loss: 0.13\n",
+      "Epoch[1], Iter[300] Loss: 0.08\n",
+      "Epoch[1], Iter[400] Loss: 0.11\n",
+      "Training Results - Epoch[1] Avg accuracy: 0.97 Avg loss: 0.09\n",
+      "Validation Results - Epoch[1] Avg accuracy: 0.97 Avg loss: 0.08\n",
+      "Epoch[2], Iter[500] Loss: 0.07\n",
+      "Epoch[2], Iter[600] Loss: 0.04\n",
+      "Epoch[2], Iter[700] Loss: 0.09\n",
+      "Epoch[2], Iter[800] Loss: 0.07\n",
+      "Epoch[2], Iter[900] Loss: 0.16\n",
+      "Training Results - Epoch[2] Avg accuracy: 0.93 Avg loss: 0.20\n",
+      "Validation Results - Epoch[2] Avg accuracy: 0.93 Avg loss: 0.20\n",
+      "Epoch[3], Iter[1000] Loss: 0.02\n",
+      "Epoch[3], Iter[1100] Loss: 0.02\n",
+      "Epoch[3], Iter[1200] Loss: 0.05\n",
+      "Epoch[3], Iter[1300] Loss: 0.06\n",
+      "Epoch[3], Iter[1400] Loss: 0.06\n",
+      "Training Results - Epoch[3] Avg accuracy: 0.94 Avg loss: 0.20\n",
+      "Validation Results - Epoch[3] Avg accuracy: 0.94 Avg loss: 0.23\n",
+      "Epoch[4], Iter[1500] Loss: 0.08\n",
+      "Epoch[4], Iter[1600] Loss: 0.02\n",
+      "Epoch[4], Iter[1700] Loss: 0.08\n",
+      "Epoch[4], Iter[1800] Loss: 0.07\n",
+      "Training Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.06\n",
+      "Validation Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.07\n",
+      "Epoch[5], Iter[1900] Loss: 0.02\n",
+      "Epoch[5], Iter[2000] Loss: 0.11\n",
+      "Epoch[5], Iter[2100] Loss: 0.05\n",
+      "Epoch[5], Iter[2200] Loss: 0.02\n",
+      "Epoch[5], Iter[2300] Loss: 0.01\n",
+      "Training Results - Epoch[5] Avg accuracy: 0.99 Avg loss: 0.02\n",
+      "Validation Results - Epoch[5] Avg accuracy: 0.99 Avg loss: 0.03\n"
+     ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "P9VjKOirEcFu"
-      },
-      "source": [
-        "Welcome to **PyTorch-Ignite**’s quick start guide that covers the\n",
-        "essentials of getting a project up and running while walking through\n",
-        "basic concepts of Ignite. In just a few lines of code, you can get your\n",
-        "model trained and validated. The complete code can be found at the end\n",
-        "of this guide.\n",
-        "\n",
-        "<!--more-->"
-      ],
-      "id": "P9VjKOirEcFu"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "1QNvbg3SEcFw"
-      },
-      "source": [
-        "## Prerequisites\n",
-        "\n",
-        "This tutorial assumes you are familiar with the:\n",
-        "\n",
-        "1.  Basics of Python and deep learning\n",
-        "2.  Structure of PyTorch code"
-      ],
-      "id": "1QNvbg3SEcFw"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "XTHzzYyoEcFy"
-      },
-      "source": [
-        "## Installation\n",
-        "\n",
-        "From `pip`\n",
-        "\n",
-        "``` shell\n",
-        "pip install pytorch-ignite\n",
-        "```\n",
-        "\n",
-        "From `conda`\n",
-        "\n",
-        "``` shell\n",
-        "conda install ignite -c pytorch\n",
-        "```\n",
-        "\n",
-        "See [here](https://pytorch-ignite.ai/how-to-guides/installation/) for other installation\n",
-        "options."
-      ],
-      "id": "XTHzzYyoEcFy"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DcnSr5sGEcFz"
-      },
-      "source": [
-        "## Code\n",
-        "\n",
-        "Import the following:"
-      ],
-      "id": "DcnSr5sGEcFz"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Saizk3heEcFz"
-      },
-      "source": [
-        "import torch\n",
-        "from torch import nn\n",
-        "from torch.utils.data import DataLoader\n",
-        "from torchvision.datasets import MNIST\n",
-        "from torchvision.models import resnet18\n",
-        "from torchvision.transforms import Compose, Normalize, ToTensor\n",
-        "\n",
-        "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
-        "from ignite.metrics import Accuracy, Loss\n",
-        "from ignite.handlers import ModelCheckpoint\n",
-        "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine"
-      ],
-      "id": "Saizk3heEcFz",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ecMYtJF7OvgT"
-      },
-      "source": [
-        "Speed things up by setting [device](https://pytorch.org/docs/stable/tensor_attributes.html#torch.torch.device) to `cuda` if available else `cpu`."
-      ],
-      "id": "ecMYtJF7OvgT"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "sdjDKcFhOuQn"
-      },
-      "source": [
-        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")"
-      ],
-      "id": "sdjDKcFhOuQn",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "4r_PUH1yEcF1"
-      },
-      "source": [
-        "Define a class of your model or use the predefined ResNet18 model (modified for MNIST) below, instantiate it and move it to device:"
-      ],
-      "id": "4r_PUH1yEcF1"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "dVSVAT0OEcF1"
-      },
-      "source": [
-        "class Net(nn.Module):\n",
-        "\n",
-        "    def __init__(self):\n",
-        "        super(Net, self).__init__()\n",
-        "        \n",
-        "        # Changed the output layer to output 10 classes instead of 1000 classes\n",
-        "        self.model = resnet18(num_classes=10)\n",
-        "\n",
-        "        # Changed the input layer to take grayscale images for MNIST instaed of RGB images\n",
-        "        self.model.conv1 = nn.Conv2d(\n",
-        "            1, 64, kernel_size=3, padding=1, bias=False\n",
-        "        )\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.model(x)\n",
-        "\n",
-        "\n",
-        "model = Net().to(device)"
-      ],
-      "id": "dVSVAT0OEcF1",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DDIW2zedEcF3"
-      },
-      "source": [
-        "Now let us define the training and validation datasets (as\n",
-        "[torch.utils.data.DataLoader](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader))\n",
-        "and store them in `train_loader` and `val_loader` respectively. We have\n",
-        "used the [MNIST](https://pytorch.org/vision/stable/datasets.html#mnist)\n",
-        "dataset for ease of understanding.\n"
-      ],
-      "id": "DDIW2zedEcF3"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "PFNgx_-TEcF4"
-      },
-      "source": [
-        "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
-        "\n",
-        "train_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=True), batch_size=128, shuffle=True\n",
-        ")\n",
-        "\n",
-        "val_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=False), batch_size=256, shuffle=False\n",
-        ")"
-      ],
-      "id": "PFNgx_-TEcF4",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VC9BUtWXEcF6"
-      },
-      "source": [
-        "Finally, we will specify the optimizer and the loss function:"
-      ],
-      "id": "VC9BUtWXEcF6"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "6VkGmtVZEcF7"
-      },
-      "source": [
-        "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
-        "criterion = nn.CrossEntropyLoss()"
-      ],
-      "id": "6VkGmtVZEcF7",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cb-ak9gEEcF7"
-      },
-      "source": [
-        "And we’re done with setting up the important parts of the project.\n",
-        "PyTorch-Ignite will handle all other boilerplate code as we will see\n",
-        "below. Next we have to define a trainer engine by passing our model,\n",
-        "optimizer and loss function to\n",
-        "[`create_supervised_trainer`](https://pytorch.org/ignite/generated/ignite.engine.create_supervised_trainer.html),\n",
-        "and two evaluator engines by passing Ignite’s out-of-the-box\n",
-        "[metrics](https://pytorch.org/ignite/metrics.html#complete-list-of-metrics)\n",
-        "and the model to\n",
-        "[`create_supervised_evaluator`](https://pytorch.org/ignite/generated/ignite.engine.create_supervised_evaluator.html#create-supervised-evaluator). We have defined separate evaluator engines for training and validation because they will serve different functions as we will see later in this tutorial:"
-      ],
-      "id": "cb-ak9gEEcF7"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "NufcPqJaEcF8"
-      },
-      "source": [
-        "trainer = create_supervised_trainer(model, optimizer, criterion, device)\n",
-        "\n",
-        "val_metrics = {\n",
-        "    \"accuracy\": Accuracy(),\n",
-        "    \"loss\": Loss(criterion)\n",
-        "}\n",
-        "\n",
-        "train_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
-        "val_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)"
-      ],
-      "id": "NufcPqJaEcF8",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "S7YThetiEcF8"
-      },
-      "source": [
-        "The objects `trainer`, `train_evaluator` and `val_evaluator` are all instances of\n",
-        "[`Engine`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine) - the main component of Ignite, which is essentially an abstraction over\n",
-        "the training or validation loop.\n",
-        "\n",
-        "If you need more control over your training and validation loops, you\n",
-        "can create custom `trainer`, `train_evaluator` and `val_evaluator` objects by wrapping the step\n",
-        "logic in `Engine` :\n",
-        "\n",
-        "```python\n",
-        "def train_step(engine, batch):\n",
-        "    model.train()\n",
-        "    optimizer.zero_grad()\n",
-        "    x, y = batch[0].to(device), batch[1].to(device)\n",
-        "    y_pred = model(x)\n",
-        "    loss = criterion(y_pred, y)\n",
-        "    loss.backward()\n",
-        "    optimizer.step()\n",
-        "    return loss.item()\n",
-        "\n",
-        "trainer = Engine(train_step)\n",
-        "\n",
-        "def validation_step(engine, batch):\n",
-        "    model.eval()\n",
-        "    with torch.no_grad():\n",
-        "        x, y = batch[0].to(device), batch[1].to(device)\n",
-        "        y_pred = model(x)\n",
-        "        return y_pred, y\n",
-        "\n",
-        "train_evaluator = Engine(validation_step)\n",
-        "val_evaluator = Engine(validation_step)\n",
-        "\n",
-        "# Attach metrics to the evaluators\n",
-        "for name, metric in val_metrics.items():\n",
-        "    metric.attach(train_evaluator, name)\n",
-        "\n",
-        "for name, metric in val_metrics.items():\n",
-        "    metric.attach(val_evaluator, name)\n",
-        "```"
-      ],
-      "id": "S7YThetiEcF8"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Sw90sOK9EcF9"
-      },
-      "source": [
-        "We can customize the code further by adding all kinds of event handlers.\n",
-        "`Engine` allows adding handlers on various events that are triggered\n",
-        "during the run. When an event is triggered, attached handlers\n",
-        "(functions) are executed. Thus, for logging purposes we add a function\n",
-        "to be executed at the end of every `log_interval`-th iteration:"
-      ],
-      "id": "Sw90sOK9EcF9"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "YGm_-loUEcF9"
-      },
-      "source": [
-        "# How many batches to wait before logging training status\n",
-        "log_interval = 100"
-      ],
-      "id": "YGm_-loUEcF9",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "V3xpFBI6EcF9"
-      },
-      "source": [
-        "@trainer.on(Events.ITERATION_COMPLETED(every=log_interval))\n",
-        "def log_training_loss(engine):\n",
-        "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")"
-      ],
-      "id": "V3xpFBI6EcF9",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "O6uwwXO8EcF-"
-      },
-      "source": [
-        "or equivalently without the decorator but attaching the handler function\n",
-        "to the `trainer` via\n",
-        "[`add_event_handler`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.add_event_handler)\n",
-        "\n",
-        "``` python\n",
-        "def log_training_loss(engine):\n",
-        "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")\n",
-        "\n",
-        "trainer.add_event_handler(Events.ITERATION_COMPLETED, log_training_loss)\n",
-        "```"
-      ],
-      "id": "O6uwwXO8EcF-"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "quQzbAv6EcF-"
-      },
-      "source": [
-        "After an epoch ends during training, we can compute the training and\n",
-        "validation metrics by running `train_evaluator` on `train_loader` and `val_evaluator` on\n",
-        "`val_loader` respectively. Hence we will attach two additional handlers to `trainer`\n",
-        "when an epoch completes:"
-      ],
-      "id": "quQzbAv6EcF-"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "eCE552PFEcF_"
-      },
-      "source": [
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_training_results(trainer):\n",
-        "    train_evaluator.run(train_loader)\n",
-        "    metrics = train_evaluator.state.metrics\n",
-        "    print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
-        "\n",
-        "\n",
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_validation_results(trainer):\n",
-        "    val_evaluator.run(val_loader)\n",
-        "    metrics = val_evaluator.state.metrics\n",
-        "    print(f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")"
-      ],
-      "id": "eCE552PFEcF_",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "7JRLbhiw903w"
-      },
-      "source": [
-        "We can use [`ModelCheckpoint()`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.ModelCheckpoint.html#modelcheckpoint) as shown below to save the `n_saved` best models determined by a metric (here accuracy) after each epoch is completed. We attach `model_checkpoint` to `val_evaluator` because we want the two models with the highest accuracies on the validation dataset rather than the training dataset. This is why we defined two separate evaluators (`val_evaluator` and `train_evaluator`) before."
-      ],
-      "id": "7JRLbhiw903w"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "W6Zd7vKn1LLO"
-      },
-      "source": [
-        "# Score function to return current value of any metric we defined above in val_metrics\n",
-        "def score_function(engine):\n",
-        "    return engine.state.metrics[\"accuracy\"]\n",
-        "\n",
-        "# Checkpoint to store n_saved best models wrt score function\n",
-        "model_checkpoint = ModelCheckpoint(\n",
-        "    \"checkpoint\",\n",
-        "    n_saved=2,\n",
-        "    filename_prefix=\"best\",\n",
-        "    score_function=score_function,\n",
-        "    score_name=\"accuracy\",\n",
-        "    global_step_transform=global_step_from_engine(trainer), # helps fetch the trainer's state\n",
-        ")\n",
-        "  \n",
-        "# Save the model after every epoch of val_evaluator is completed\n",
-        "val_evaluator.add_event_handler(Events.COMPLETED, model_checkpoint, {\"model\": model})"
-      ],
-      "id": "W6Zd7vKn1LLO",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "KAB0QtrgiTLK"
-      },
-      "source": [
-        "We will use [`TensorboardLogger()`](https://pytorch.org/ignite/generated/ignite.contrib.handlers.tensorboard_logger.html#ignite.contrib.handlers.tensorboard_logger.TensorboardLogger) to log trainer's loss, and training and validation metrics separately."
-      ],
-      "id": "KAB0QtrgiTLK"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Rdt6AE6oeh6k"
-      },
-      "source": [
-        "# Define a Tensorboard logger\n",
-        "tb_logger = TensorboardLogger(log_dir=\"tb-logger\")\n",
-        "\n",
-        "# Attach handler to plot trainer's loss every 100 iterations\n",
-        "tb_logger.attach_output_handler(\n",
-        "    trainer,\n",
-        "    event_name=Events.ITERATION_COMPLETED(every=100),\n",
-        "    tag=\"training\",\n",
-        "    output_transform=lambda loss: {\"batch_loss\": loss},\n",
-        ")\n",
-        "\n",
-        "# Attach handler for plotting both evaluators' metrics after every epoch completes\n",
-        "for tag, evaluator in [(\"training\", train_evaluator), (\"validation\", val_evaluator)]:\n",
-        "    tb_logger.attach_output_handler(\n",
-        "        evaluator,\n",
-        "        event_name=Events.EPOCH_COMPLETED,\n",
-        "        tag=tag,\n",
-        "        metric_names=\"all\",\n",
-        "        global_step_transform=global_step_from_engine(trainer),\n",
-        "    )"
-      ],
-      "id": "Rdt6AE6oeh6k",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Aq0qwiZrEcF_"
-      },
-      "source": [
-        "Finally, we start the engine on the training dataset and run it for 5\n",
-        "epochs:"
-      ],
-      "id": "Aq0qwiZrEcF_"
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "qnmTh4FeEcGA",
-        "outputId": "f444d98f-8f45-44ea-bd82-9cecb6971bbe"
-      },
-      "source": [
-        "trainer.run(train_loader, max_epochs=5)"
-      ],
-      "id": "qnmTh4FeEcGA",
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Epoch[1], Iter[100] Loss: 0.19\n",
-            "Epoch[1], Iter[200] Loss: 0.13\n",
-            "Epoch[1], Iter[300] Loss: 0.08\n",
-            "Epoch[1], Iter[400] Loss: 0.11\n",
-            "Training Results - Epoch[1] Avg accuracy: 0.97 Avg loss: 0.09\n",
-            "Validation Results - Epoch[1] Avg accuracy: 0.97 Avg loss: 0.08\n",
-            "Epoch[2], Iter[500] Loss: 0.07\n",
-            "Epoch[2], Iter[600] Loss: 0.04\n",
-            "Epoch[2], Iter[700] Loss: 0.09\n",
-            "Epoch[2], Iter[800] Loss: 0.07\n",
-            "Epoch[2], Iter[900] Loss: 0.16\n",
-            "Training Results - Epoch[2] Avg accuracy: 0.93 Avg loss: 0.20\n",
-            "Validation Results - Epoch[2] Avg accuracy: 0.93 Avg loss: 0.20\n",
-            "Epoch[3], Iter[1000] Loss: 0.02\n",
-            "Epoch[3], Iter[1100] Loss: 0.02\n",
-            "Epoch[3], Iter[1200] Loss: 0.05\n",
-            "Epoch[3], Iter[1300] Loss: 0.06\n",
-            "Epoch[3], Iter[1400] Loss: 0.06\n",
-            "Training Results - Epoch[3] Avg accuracy: 0.94 Avg loss: 0.20\n",
-            "Validation Results - Epoch[3] Avg accuracy: 0.94 Avg loss: 0.23\n",
-            "Epoch[4], Iter[1500] Loss: 0.08\n",
-            "Epoch[4], Iter[1600] Loss: 0.02\n",
-            "Epoch[4], Iter[1700] Loss: 0.08\n",
-            "Epoch[4], Iter[1800] Loss: 0.07\n",
-            "Training Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.06\n",
-            "Validation Results - Epoch[4] Avg accuracy: 0.98 Avg loss: 0.07\n",
-            "Epoch[5], Iter[1900] Loss: 0.02\n",
-            "Epoch[5], Iter[2000] Loss: 0.11\n",
-            "Epoch[5], Iter[2100] Loss: 0.05\n",
-            "Epoch[5], Iter[2200] Loss: 0.02\n",
-            "Epoch[5], Iter[2300] Loss: 0.01\n",
-            "Training Results - Epoch[5] Avg accuracy: 0.99 Avg loss: 0.02\n",
-            "Validation Results - Epoch[5] Avg accuracy: 0.99 Avg loss: 0.03\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "State:\n",
-              "\titeration: 2345\n",
-              "\tepoch: 5\n",
-              "\tepoch_length: 469\n",
-              "\tmax_epochs: 5\n",
-              "\toutput: 0.005351857747882605\n",
-              "\tbatch: <class 'list'>\n",
-              "\tmetrics: <class 'dict'>\n",
-              "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
-              "\tseed: <class 'NoneType'>\n",
-              "\ttimes: <class 'dict'>"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 85
-        }
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 2345\n",
+       "\tepoch: 5\n",
+       "\tepoch_length: 469\n",
+       "\tmax_epochs: 5\n",
+       "\toutput: 0.005351857747882605\n",
+       "\tbatch: <class 'list'>\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'torch.utils.data.dataloader.DataLoader'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>"
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "ZXhL1-vDgBeT"
-      },
-      "source": [
-        "# Let's close the logger and inspect our results\n",
-        "tb_logger.close()\n",
-        "\n",
-        "%load_ext tensorboard\n",
-        "\n",
-        "%tensorboard --logdir=."
-      ],
-      "id": "ZXhL1-vDgBeT",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "_xj4NMjdArYh",
-        "outputId": "3291ca3b-809a-4ed4-d657-0b83eeb45bc5"
-      },
-      "source": [
-        "# At last we can view our best models\n",
-        "!ls checkpoints"
-      ],
-      "id": "_xj4NMjdArYh",
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "'best_model_4_accuracy=0.9856.pt'  'best_model_5_accuracy=0.9857.pt'\n"
-          ],
-          "name": "stdout"
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wJ9k2coEEcGD"
-      },
-      "source": [
-        "## Next Steps\n",
-        "\n",
-        "1.  Check out [tutorials](https://pytorch-ignite.ai/tutorials) if you want to continue\n",
-        "    learning more about PyTorch-Ignite.\n",
-        "2.  Head over to [how-to guides](https://pytorch-ignite.ai/how-to-guides) if you’re looking\n",
-        "    for a specific solution.\n",
-        "3.  If you want to set-up a PyTorch-Ignite project, visit [Code\n",
-        "    Generator](https://code-generator.pytorch-ignite.ai/) to get a variety of\n",
-        "    easily customizable templates and out-of-the-box features."
-      ],
-      "id": "wJ9k2coEEcGD"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "tags": [],
-        "id": "vya75pqVEcGE"
-      },
-      "source": [
-        "## Complete Code\n",
-        "\n",
-        "``` python\n",
-        "import torch\n",
-        "from torch import nn\n",
-        "from torch.utils.data import DataLoader\n",
-        "from torchvision.datasets import MNIST\n",
-        "from torchvision.models import resnet18\n",
-        "from torchvision.transforms import Compose, Normalize, ToTensor\n",
-        "\n",
-        "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
-        "from ignite.metrics import Accuracy, Loss\n",
-        "from ignite.handlers import ModelCheckpoint\n",
-        "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
-        "\n",
-        "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-        "\n",
-        "\n",
-        "class Net(nn.Module):\n",
-        "\n",
-        "    def __init__(self):\n",
-        "        super(Net, self).__init__()\n",
-        "    \n",
-        "        self.model = resnet18(num_classes=10)\n",
-        "\n",
-        "        self.model.conv1 = self.model.conv1 = nn.Conv2d(\n",
-        "            1, 64, kernel_size=3, padding=1, bias=False\n",
-        "        )\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.model(x)\n",
-        "\n",
-        "\n",
-        "model = Net().to(device)\n",
-        "\n",
-        "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
-        "\n",
-        "train_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=True), batch_size=128, shuffle=True\n",
-        ")\n",
-        "\n",
-        "val_loader = DataLoader(\n",
-        "    MNIST(download=True, root=\".\", transform=data_transform, train=False), batch_size=256, shuffle=False\n",
-        ")\n",
-        "\n",
-        "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
-        "criterion = nn.CrossEntropyLoss()\n",
-        "\n",
-        "trainer = create_supervised_trainer(model, optimizer, criterion, device)\n",
-        "\n",
-        "val_metrics = {\n",
-        "    \"accuracy\": Accuracy(),\n",
-        "    \"loss\": Loss(criterion)\n",
-        "}\n",
-        "\n",
-        "train_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
-        "val_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
-        "\n",
-        "log_interval = 100\n",
-        "\n",
-        "@trainer.on(Events.ITERATION_COMPLETED(every=log_interval))\n",
-        "def log_training_loss(engine):\n",
-        "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")\n",
-        "\n",
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_training_results(trainer):\n",
-        "    train_evaluator.run(train_loader)\n",
-        "    metrics = train_evaluator.state.metrics\n",
-        "    print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
-        "\n",
-        "\n",
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_validation_results(trainer):\n",
-        "    val_evaluator.run(val_loader)\n",
-        "    metrics = val_evaluator.state.metrics\n",
-        "    print(f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
-        "\n",
-        "\n",
-        "def score_function(engine):\n",
-        "    return engine.state.metrics[\"accuracy\"]\n",
-        "\n",
-        "\n",
-        "model_checkpoint = ModelCheckpoint(\n",
-        "    \"checkpoint\",\n",
-        "    n_saved=2,\n",
-        "    filename_prefix=\"best\",\n",
-        "    score_function=score_function,\n",
-        "    score_name=\"accuracy\",\n",
-        "    global_step_transform=global_step_from_engine(trainer),\n",
-        ")\n",
-        "  \n",
-        "val_evaluator.add_event_handler(Events.COMPLETED, model_checkpoint, {\"model\": model})\n",
-        "\n",
-        "tb_logger = TensorboardLogger(log_dir=\"tb-logger\")\n",
-        "\n",
-        "tb_logger.attach_output_handler(\n",
-        "    trainer,\n",
-        "    event_name=Events.ITERATION_COMPLETED(every=100),\n",
-        "    tag=\"training\",\n",
-        "    output_transform=lambda loss: {\"batch_loss\": loss},\n",
-        ")\n",
-        "\n",
-        "for tag, evaluator in [(\"training\", train_evaluator), (\"validation\", val_evaluator)]:\n",
-        "    tb_logger.attach_output_handler(\n",
-        "        evaluator,\n",
-        "        event_name=Events.EPOCH_COMPLETED,\n",
-        "        tag=tag,\n",
-        "        metric_names=\"all\",\n",
-        "        global_step_transform=global_step_from_engine(trainer),\n",
-        "    )\n",
-        "\n",
-        "trainer.run(train_loader, max_epochs=5)\n",
-        "\n",
-        "tb_logger.close()\n",
-        "```"
-      ],
-      "id": "vya75pqVEcGE"
+     },
+     "execution_count": 85,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
     }
-  ]
+   ],
+   "source": [
+    "trainer.run(train_loader, max_epochs=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ZXhL1-vDgBeT",
+   "metadata": {
+    "id": "ZXhL1-vDgBeT"
+   },
+   "outputs": [],
+   "source": [
+    "# Let's close the logger and inspect our results\n",
+    "tb_logger.close()\n",
+    "\n",
+    "%load_ext tensorboard\n",
+    "\n",
+    "%tensorboard --logdir=."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "_xj4NMjdArYh",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "_xj4NMjdArYh",
+    "outputId": "3291ca3b-809a-4ed4-d657-0b83eeb45bc5"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'best_model_4_accuracy=0.9856.pt'  'best_model_5_accuracy=0.9857.pt'\n"
+     ]
+    }
+   ],
+   "source": [
+    "# At last we can view our best models\n",
+    "!ls checkpoints"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wJ9k2coEEcGD",
+   "metadata": {
+    "id": "wJ9k2coEEcGD"
+   },
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "1.  Check out [tutorials](https://pytorch-ignite.ai/tutorials) if you want to continue\n",
+    "    learning more about PyTorch-Ignite.\n",
+    "2.  Head over to [how-to guides](https://pytorch-ignite.ai/how-to-guides) if you’re looking\n",
+    "    for a specific solution.\n",
+    "3.  If you want to set-up a PyTorch-Ignite project, visit [Code\n",
+    "    Generator](https://code-generator.pytorch-ignite.ai/) to get a variety of\n",
+    "    easily customizable templates and out-of-the-box features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vya75pqVEcGE",
+   "metadata": {
+    "id": "vya75pqVEcGE",
+    "tags": []
+   },
+   "source": [
+    "## Complete Code\n",
+    "\n",
+    "``` python\n",
+    "import torch\n",
+    "from torch import nn\n",
+    "from torch.utils.data import DataLoader\n",
+    "from torchvision.datasets import MNIST\n",
+    "from torchvision.models import resnet18\n",
+    "from torchvision.transforms import Compose, Normalize, ToTensor\n",
+    "\n",
+    "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
+    "from ignite.metrics import Accuracy, Loss\n",
+    "from ignite.handlers import ModelCheckpoint\n",
+    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
+    "\n",
+    "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "\n",
+    "class Net(nn.Module):\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        super(Net, self).__init__()\n",
+    "    \n",
+    "        self.model = resnet18(num_classes=10)\n",
+    "\n",
+    "        self.model.conv1 = self.model.conv1 = nn.Conv2d(\n",
+    "            1, 64, kernel_size=3, padding=1, bias=False\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.model(x)\n",
+    "\n",
+    "\n",
+    "model = Net().to(device)\n",
+    "\n",
+    "data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])\n",
+    "\n",
+    "train_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=True), batch_size=128, shuffle=True\n",
+    ")\n",
+    "\n",
+    "val_loader = DataLoader(\n",
+    "    MNIST(download=True, root=\".\", transform=data_transform, train=False), batch_size=256, shuffle=False\n",
+    ")\n",
+    "\n",
+    "optimizer = torch.optim.RMSprop(model.parameters(), lr=0.005)\n",
+    "criterion = nn.CrossEntropyLoss()\n",
+    "\n",
+    "trainer = create_supervised_trainer(model, optimizer, criterion, device)\n",
+    "\n",
+    "val_metrics = {\n",
+    "    \"accuracy\": Accuracy(),\n",
+    "    \"loss\": Loss(criterion)\n",
+    "}\n",
+    "\n",
+    "train_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
+    "val_evaluator = create_supervised_evaluator(model, metrics=val_metrics, device=device)\n",
+    "\n",
+    "log_interval = 100\n",
+    "\n",
+    "@trainer.on(Events.ITERATION_COMPLETED(every=log_interval))\n",
+    "def log_training_loss(engine):\n",
+    "    print(f\"Epoch[{engine.state.epoch}], Iter[{engine.state.iteration}] Loss: {engine.state.output:.2f}\")\n",
+    "\n",
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_training_results(trainer):\n",
+    "    train_evaluator.run(train_loader)\n",
+    "    metrics = train_evaluator.state.metrics\n",
+    "    print(f\"Training Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
+    "\n",
+    "\n",
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_validation_results(trainer):\n",
+    "    val_evaluator.run(val_loader)\n",
+    "    metrics = val_evaluator.state.metrics\n",
+    "    print(f\"Validation Results - Epoch[{trainer.state.epoch}] Avg accuracy: {metrics['accuracy']:.2f} Avg loss: {metrics['loss']:.2f}\")\n",
+    "\n",
+    "\n",
+    "def score_function(engine):\n",
+    "    return engine.state.metrics[\"accuracy\"]\n",
+    "\n",
+    "\n",
+    "model_checkpoint = ModelCheckpoint(\n",
+    "    \"checkpoint\",\n",
+    "    n_saved=2,\n",
+    "    filename_prefix=\"best\",\n",
+    "    score_function=score_function,\n",
+    "    score_name=\"accuracy\",\n",
+    "    global_step_transform=global_step_from_engine(trainer),\n",
+    ")\n",
+    "  \n",
+    "val_evaluator.add_event_handler(Events.COMPLETED, model_checkpoint, {\"model\": model})\n",
+    "\n",
+    "tb_logger = TensorboardLogger(log_dir=\"tb-logger\")\n",
+    "\n",
+    "tb_logger.attach_output_handler(\n",
+    "    trainer,\n",
+    "    event_name=Events.ITERATION_COMPLETED(every=100),\n",
+    "    tag=\"training\",\n",
+    "    output_transform=lambda loss: {\"batch_loss\": loss},\n",
+    ")\n",
+    "\n",
+    "for tag, evaluator in [(\"training\", train_evaluator), (\"validation\", val_evaluator)]:\n",
+    "    tb_logger.attach_output_handler(\n",
+    "        evaluator,\n",
+    "        event_name=Events.EPOCH_COMPLETED,\n",
+    "        tag=tag,\n",
+    "        metric_names=\"all\",\n",
+    "        global_step_transform=global_step_from_engine(trainer),\n",
+    "    )\n",
+    "\n",
+    "trainer.run(train_loader, max_epochs=5)\n",
+    "\n",
+    "tb_logger.close()\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "getting-started.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/tutorials/beginner/02-transformers-text-classification.ipynb
+++ b/tutorials/beginner/02-transformers-text-classification.ipynb
@@ -1,750 +1,750 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HCS-d1T3znj2"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: Transformers for Text Classification with IMDb Reviews\n",
-        "date: 2021-09-18\n",
-        "downloads: true\n",
-        "weight: 2\n",
-        "tags:\n",
-        "  - NLP\n",
-        "  - BERT\n",
-        "  - Transformers\n",
-        "  - Text\n",
-        "  - Beginner\n",
-        "--- -->\n",
-        "# Transformers for Text Classification with IMDb Reviews"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rjZMYxFoznj9"
-      },
-      "source": [
-        "In this tutorial we will fine tune a model from the Transformers library for text classification using PyTorch-Ignite. We will be following the [Fine-tuning a pretrained model](https://huggingface.co/transformers/training.html) tutorial for preprocessing text and defining the model, optimizer and dataloaders. <!--more--> Then we are going to use Ignite for:\n",
-        "* Training and evaluating the model\n",
-        "* Computing metrics\n",
-        "* Setting up experiments and monitoring the model\n",
-        "\n",
-        "According to the tutorial, we will use the [IMDb Movie Reviews Dataset](https://ai.stanford.edu/~amaas/data/sentiment/) to classify a review as either positive or negative."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sovYyC0Zznj-"
-      },
-      "source": [
-        "## Required Dependencies "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7XHAD9x7znj_"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install pytorch-ignite transformers datasets"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "I80XSUXpvk1i"
-      },
-      "source": [
-        "Before we dive in, we will seed everything using [`manual_seed`](https://pytorch.org/ignite/utils.html#ignite.utils.manual_seed)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "id": "enczLgLTznkH"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.utils import manual_seed\n",
-        "\n",
-        "manual_seed(42)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WZYyXYB5znkH"
-      },
-      "source": [
-        "## Basic Setup\n",
-        "\n",
-        "Next we will follow the tutorial and load up our dataset and tokenizer to prepocess the data."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gCVrdHOVgjtH"
-      },
-      "source": [
-        "### Data Preprocessing"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "PQ80tXFPwAnR"
-      },
-      "outputs": [],
-      "source": [
-        "from datasets import load_dataset\n",
-        "\n",
-        "raw_datasets = load_dataset(\"imdb\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "inP62g7LwV5n"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import AutoTokenizer\n",
-        "\n",
-        "tokenizer = AutoTokenizer.from_pretrained(\"bert-base-cased\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "aQgWjFq1yESe"
-      },
-      "outputs": [],
-      "source": [
-        "def tokenize_function(examples):\n",
-        "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
-        "\n",
-        "tokenized_datasets = raw_datasets.map(tokenize_function, batched=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "xnLbsx2Jhurm"
-      },
-      "source": [
-        "We move towards the end of the tutorial for PyTorch specific instructions. Here we are extracting a larger subset of our original datasets. We also don't need to provide a seed since we seeded everything at the beginning."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 6,
-      "metadata": {
-        "id": "iPQy_FMcxBy3"
-      },
-      "outputs": [],
-      "source": [
-        "tokenized_datasets = tokenized_datasets.remove_columns([\"text\"])\n",
-        "tokenized_datasets = tokenized_datasets.rename_column(\"label\", \"labels\")\n",
-        "tokenized_datasets.set_format(\"torch\")\n",
-        "\n",
-        "small_train_dataset = tokenized_datasets[\"train\"].shuffle().select(range(5000))\n",
-        "small_eval_dataset = tokenized_datasets[\"test\"].shuffle().select(range(5000))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0JvnKjqRiEFP"
-      },
-      "source": [
-        "### Dataloaders"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {
-        "id": "APNr5lgsygtw"
-      },
-      "outputs": [],
-      "source": [
-        "from torch.utils.data import DataLoader\n",
-        "\n",
-        "train_dataloader = DataLoader(small_train_dataset, shuffle=True, batch_size=8)\n",
-        "eval_dataloader = DataLoader(small_eval_dataset, batch_size=8)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ax8ToOAviGGS"
-      },
-      "source": [
-        "### Model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XVS15FELytIj"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import AutoModelForSequenceClassification\n",
-        "\n",
-        "model = AutoModelForSequenceClassification.from_pretrained(\"bert-base-cased\", num_labels=2)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "QOI8dLDDiI7c"
-      },
-      "source": [
-        "### Optimizer"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 9,
-      "metadata": {
-        "id": "RIihFsPryvI_"
-      },
-      "outputs": [],
-      "source": [
-        "from transformers import AdamW\n",
-        "\n",
-        "optimizer = AdamW(model.parameters(), lr=5e-5)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0-Yd47-UiLFs"
-      },
-      "source": [
-        "### LR Scheduler\n",
-        "\n",
-        "We will use the built-in Ignite alternative of `linear` scheduler which is [`PiecewiseLinear`](https://pytorch.org/ignite/generated/ignite.handlers.param_scheduler.PiecewiseLinear.html#piecewiselinear). We will also increase the number of epochs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "U5gBJL-uS9WG"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.contrib.handlers import PiecewiseLinear\n",
-        "\n",
-        "num_epochs = 10\n",
-        "num_training_steps = num_epochs * len(train_dataloader)\n",
-        "\n",
-        "milestones_values = [\n",
-        "        (0, 5e-5),\n",
-        "        (num_training_steps, 0.0),\n",
-        "    ]\n",
-        "lr_scheduler = PiecewiseLinear(\n",
-        "        optimizer, param_name=\"lr\", milestones_values=milestones_values\n",
-        "    )"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vEPNZEO8jRSf"
-      },
-      "source": [
-        "### Set Device"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "A0WXnFD7bg2C"
-      },
-      "outputs": [],
-      "source": [
-        "import torch\n",
-        "\n",
-        "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
-        "model.to(device)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "elcEG2gojTsI"
-      },
-      "source": [
-        "## Create Trainer\n",
-        "\n",
-        "Ignite's [`Engine`](https://pytorch.org/ignite/concepts.html#engine) allows users to define a `process_function` to process a given batch of data. This function is applied to all the batches of the dataset. This is a general class that can be applied to train and validate models. A `process_function` has two parameters `engine` and `batch`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "iVoVnJTlWau5"
-      },
-      "source": [
-        "The code for processing a batch of training data in the tutorial is as follows:\n",
-        "\n",
-        "```python\n",
-        "for batch in train_dataloader:\n",
-        "    batch = {k: v.to(device) for k, v in batch.items()}\n",
-        "    outputs = model(**batch)\n",
-        "    loss = outputs.loss\n",
-        "    loss.backward()\n",
-        "\n",
-        "    optimizer.step()\n",
-        "    lr_scheduler.step()\n",
-        "    optimizer.zero_grad()\n",
-        "    progress_bar.update(1)\n",
-        "```\n",
-        "\n",
-        "Therefore we will define a `process_function` (called `train_step` below) to do the above tasks:\n",
-        "\n",
-        "* Set `model` in train mode. \n",
-        "* Move items of the `batch` to `device`.\n",
-        "* Perform forward pass and generate `output`.\n",
-        "* Extract loss.\n",
-        "* Perform backward pass using loss to calculate gradients for the model parameters.\n",
-        "* Optimize model parameters using gradients and optimizer.\n",
-        "\n",
-        "Finally, we choose to return the `loss` so we can utilize it for futher processing.\n",
-        "\n",
-        "You will also notice that we do not update the `lr_scheduler` and `progress_bar` in `train_step`. This is because Ignite automatically takes care of it as we will see later in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 37,
-      "metadata": {
-        "id": "Q4ncIcYcznkQ"
-      },
-      "outputs": [],
-      "source": [
-        "def train_step(engine, batch):  \n",
-        "    model.train()\n",
-        "    \n",
-        "    batch = {k: v.to(device) for k, v in batch.items()}\n",
-        "    outputs = model(**batch)\n",
-        "    loss = outputs.loss\n",
-        "    loss.backward()\n",
-        "\n",
-        "    optimizer.step()\n",
-        "    optimizer.zero_grad()\n",
-        "\n",
-        "    return loss"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "n1rXDRO4Y_dp"
-      },
-      "source": [
-        "And then we create a model `trainer` by attaching the `train_step` to the training engine. Later, we will use `trainer` for looping over the training dataset for `num_epochs`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 38,
-      "metadata": {
-        "id": "LFWgXnX4cWV1"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.engine import Engine\n",
-        "\n",
-        "trainer = Engine(train_step)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "U4Wx_3rrns0a"
-      },
-      "source": [
-        "The `lr_scheduler` we defined perviously was a handler. \n",
-        "\n",
-        "[Handlers](https://pytorch.org/ignite/concepts.html#handlers) can be any type of function (lambda functions, class methods, etc). On top of that, Ignite provides several built-in handlers to reduce redundant code. We attach these handlers to engine which is triggered at a specific [event](https://pytorch.org/ignite/concepts.html#events-and-handlers). These events can be anything like the start of an iteration or the end of an epoch. [Here](https://pytorch.org/ignite/generated/ignite.engine.events.Events.html#events) is a complete list of built-in events.\n",
-        "\n",
-        "Therefore, we will attach the `lr_scheduler` (handler) to the `trainer` (`engine`) via [`add_event_handler()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.add_event_handler) so it can be triggered at `Events.ITERATION_STARTED` (start of an iteration) automatically."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "LauRCX2Vi8Su"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.engine import Events\n",
-        "\n",
-        "trainer.add_event_handler(Events.ITERATION_STARTED, lr_scheduler)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "vPXFO_3dc2ll"
-      },
-      "source": [
-        "This is the reason we did not include `lr_scheduler.step()` in `train_step()`."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bNSOB05LjfVB"
-      },
-      "source": [
-        "## Progress Bar\n",
-        "\n",
-        "Next we create an instance of Ignite's [`ProgessBar()`](https://pytorch.org/ignite/generated/ignite.contrib.handlers.tqdm_logger.html#ignite.contrib.handlers.tqdm_logger.ProgressBar) and attach it to the trainer to replace `progress_bar.update(1)`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 40,
-      "metadata": {
-        "id": "PxSVmnLica2c"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.contrib.handlers import ProgressBar\n",
-        "\n",
-        "pbar = ProgressBar()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "X9KSg4s5eLJn"
-      },
-      "source": [
-        "We can either, simply track the progress:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 29,
-      "metadata": {
-        "id": "C7t_K2MOd6qp"
-      },
-      "outputs": [],
-      "source": [
-        "pbar.attach(trainer)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sxwfbhkCeRf0"
-      },
-      "source": [
-        "Or also track the output of `trainer` (or `train_step`):"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 41,
-      "metadata": {
-        "id": "Ib1uF2GHeQlt"
-      },
-      "outputs": [],
-      "source": [
-        "pbar.attach(trainer, output_transform=lambda x: {'loss': x})"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Bf7_CjXvjj0K"
-      },
-      "source": [
-        "## Create Evaluator\n",
-        "\n",
-        "Similar to the training `process_function`, we setup a function to evaluate a single batch of train/validation/test data.\n",
-        "\n",
-        "```python\n",
-        "model.eval()\n",
-        "for batch in eval_dataloader:\n",
-        "    batch = {k: v.to(device) for k, v in batch.items()}\n",
-        "    with torch.no_grad():\n",
-        "        outputs = model(**batch)\n",
-        "\n",
-        "    logits = outputs.logits\n",
-        "    predictions = torch.argmax(logits, dim=-1)\n",
-        "    metric.add_batch(predictions=predictions, references=batch[\"labels\"])\n",
-        "```\n",
-        "\n",
-        " Here is what `evaluate_step()` below does:\n",
-        "\n",
-        "* Sets model in eval mode.\n",
-        "* Move items of the `batch` to `device`.\n",
-        "* With `torch.no_grad()`, no gradients are calculated for any succeding steps.\n",
-        "* Perform a forward pass on the model to calculate `outputs` from `batch`\n",
-        "* Get the real `predictions` from `logits` (probability of positive and negative classes).\n",
-        "\n",
-        "Finally, we return the predictions and the actual labels so that we can compute the metrics.\n",
-        "\n",
-        "You will notice that we did not compute the metrics in `evaluate_step()`. This is because Ignite provides built-in [metrics](https://pytorch.org/ignite/concepts.html#metrics) which we can later attach to the engine."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "98H3y4xagmao"
-      },
-      "source": [
-        "**Note:** Ignite suggests attaching metrics to evaluators and not trainers because during the training the model parameters are constantly changing and it is best to evaluate model on a stationary model. This information is important as there is a difference in the functions for training and evaluating. Training returns a single scalar loss. Evaluating returns `y_pred` and `y` as that output is used to calculate metrics per batch for the entire dataset.\n",
-        "\n",
-        "All metrics in Ignite require `y_pred` and `y` as outputs of the function attached to the Engine. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "metadata": {
-        "id": "H3F69ZOwcUdQ"
-      },
-      "outputs": [],
-      "source": [
-        "def evaluate_step(engine, batch):\n",
-        "    model.eval()\n",
-        "\n",
-        "    batch = {k: v.to(device) for k, v in batch.items()}\n",
-        "    with torch.no_grad():\n",
-        "        outputs = model(**batch)\n",
-        "\n",
-        "    logits = outputs.logits\n",
-        "    predictions = torch.argmax(logits, dim=-1)\n",
-        "\n",
-        "    return {'y_pred': predictions, 'y': batch[\"labels\"]}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VFrSJYx-mutP"
-      },
-      "source": [
-        "Below we create two engines, a training evaluator and a validation evaluator. `train_evaluator` and `validation_evaluator` use the same function but they serve different purposes as we will see later in this tutorial."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 43,
-      "metadata": {
-        "id": "xfxf_TGadIjc"
-      },
-      "outputs": [],
-      "source": [
-        "train_evaluator = Engine(evaluate_step)\n",
-        "validation_evaluator = Engine(evaluate_step)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ESp1oe8jjtI6"
-      },
-      "source": [
-        "## Attach Metrics\n",
-        "\n",
-        "The 🤗 tutorial defines one metric, accuracy, to be used for evaluation:\n",
-        "\n",
-        "```python\n",
-        "metric= load_metric(\"accuracy\")\n",
-        "```\n",
-        "\n",
-        "We can easily attach Ignite's built-in [`Accuracy()`](https://pytorch.org/ignite/generated/ignite.metrics.Accuracy.html#accuracy) metric to to `train_evaluator` and `validation_evaluator`. We also need to specify the metric name (`accuracy` below). Internally, it will use `y_pred` and `y` to compute the accuracy. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 44,
-      "metadata": {
-        "id": "RsT3Yq1sd5Os"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.metrics import Accuracy\n",
-        "\n",
-        "Accuracy().attach(train_evaluator, 'accuracy')\n",
-        "Accuracy().attach(validation_evaluator, 'accuracy')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "so6yub_fjydU"
-      },
-      "source": [
-        "## Log Metrics\n",
-        "\n",
-        "Now we will define custom handlers (functions) and attach them to various `Events` of the training process.\n",
-        "\n",
-        "The functions below both achieve similar tasks. They print the results of the `evaluator` run on a dataset. `log_training_results()` does this on the training evaluator and train dataset, while `log_validation_results()` on the validation evaluator and validation dataset. Another difference is how these functions are attached in the trainer engine.\n",
-        "\n",
-        "The first method involves using a decorator, the syntax is simple - `@` `trainer.on(Events.EPOCH_COMPLETED)`, means that the decorated function will be attached to the trainer and called at the end of each epoch. \n",
-        "\n",
-        "The second method involves using the add_event_handler method of trainer - `trainer.add_event_handler(Events.EPOCH_COMPLETED, custom_function)`. This achieves the same result as the above. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "mrl-60C9aEkW"
-      },
-      "outputs": [],
-      "source": [
-        "@trainer.on(Events.EPOCH_COMPLETED)\n",
-        "def log_training_results(engine):\n",
-        "    train_evaluator.run(train_dataloader)\n",
-        "    metrics = train_evaluator.state.metrics\n",
-        "    avg_accuracy = metrics['accuracy']\n",
-        "    print(f\"Training Results - Epoch: {engine.state.epoch}  Avg accuracy: {avg_accuracy:.3f}\")\n",
-        "    \n",
-        "def log_validation_results(engine):\n",
-        "    validation_evaluator.run(eval_dataloader)\n",
-        "    metrics = validation_evaluator.state.metrics\n",
-        "    avg_accuracy = metrics['accuracy']\n",
-        "    print(f\"Validation Results - Epoch: {engine.state.epoch}  Avg accuracy: {avg_accuracy:.3f}\")\n",
-        "\n",
-        "trainer.add_event_handler(Events.EPOCH_COMPLETED, log_validation_results)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "fGbSjScZj2Bt"
-      },
-      "source": [
-        "## Early Stopping\n",
-        "\n",
-        "Now we'll setup a [`EarlyStopping`](https://pytorch.org/ignite/generated/ignite.handlers.early_stopping.EarlyStopping.html#earlystopping) handler for the training process. `EarlyStopping` requires a score_function that allows the user to define whatever criteria to stop trainig. In this case, if the loss of the validation set does not decrease in 2 epochs (`patience`), the training process will stop early.  "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "O0xElFVYeuL9"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.handlers import EarlyStopping\n",
-        "\n",
-        "def score_function(engine):\n",
-        "    val_accuracy = engine.state.metrics['accuracy']\n",
-        "    return val_accuracy\n",
-        "\n",
-        "handler = EarlyStopping(patience=2, score_function=score_function, trainer=trainer)\n",
-        "validation_evaluator.add_event_handler(Events.COMPLETED, handler)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C1UtBUmmj9dq"
-      },
-      "source": [
-        "## Model Checkpoint\n",
-        "\n",
-        "Lastly, we want to save the best model weights. So we will use Ignite's [`ModelCheckpoint`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.ModelCheckpoint.html#modelcheckpoint) handler to checkpoint models at the end of each epoch. This will create a `models` directory and save the 2 best models (`n_saved`) with the prefix `bert-base-cased`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "7xz8qozReQuG"
-      },
-      "outputs": [],
-      "source": [
-        "from ignite.handlers import ModelCheckpoint\n",
-        "\n",
-        "checkpointer = ModelCheckpoint(dirname='models', filename_prefix='bert-base-cased', n_saved=2, create_dir=True)\n",
-        "trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpointer, {'model': model})"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "jgzcQVfvkAXK"
-      },
-      "source": [
-        "## Begin Training!\n",
-        "\n",
-        "Next, we'll run the trainer for 10 epochs and monitor the results. Below we can see that `ProgessBar` prints the loss per iteration, and prints the results of training and validation as we specified in our custom function. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "sS0Ut5z0dmQc"
-      },
-      "outputs": [],
-      "source": [
-        "trainer.run(train_dataloader, max_epochs=num_epochs)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OpqXiZUsznkY"
-      },
-      "source": [
-        "That's it! We have successfully trained and evaluated a Transformer for Text Classification. "
-      ]
-    }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "collapsed_sections": [],
-      "name": "transformers-text-classification.ipynb",
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HCS-d1T3znj2"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: Transformers for Text Classification with IMDb Reviews\n",
+    "date: 2021-09-18\n",
+    "downloads: true\n",
+    "weight: 2\n",
+    "tags:\n",
+    "  - NLP\n",
+    "  - BERT\n",
+    "  - Transformers\n",
+    "  - Text\n",
+    "  - Beginner\n",
+    "--- -->\n",
+    "# Transformers for Text Classification with IMDb Reviews"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rjZMYxFoznj9"
+   },
+   "source": [
+    "In this tutorial we will fine tune a model from the Transformers library for text classification using PyTorch-Ignite. We will be following the [Fine-tuning a pretrained model](https://huggingface.co/transformers/training.html) tutorial for preprocessing text and defining the model, optimizer and dataloaders. <!--more--> Then we are going to use Ignite for:\n",
+    "* Training and evaluating the model\n",
+    "* Computing metrics\n",
+    "* Setting up experiments and monitoring the model\n",
+    "\n",
+    "According to the tutorial, we will use the [IMDb Movie Reviews Dataset](https://ai.stanford.edu/~amaas/data/sentiment/) to classify a review as either positive or negative."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sovYyC0Zznj-"
+   },
+   "source": [
+    "## Required Dependencies "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7XHAD9x7znj_"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install pytorch-ignite transformers datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "I80XSUXpvk1i"
+   },
+   "source": [
+    "Before we dive in, we will seed everything using [`manual_seed`](https://pytorch.org/ignite/utils.html#ignite.utils.manual_seed)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "id": "enczLgLTznkH"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.utils import manual_seed\n",
+    "\n",
+    "manual_seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WZYyXYB5znkH"
+   },
+   "source": [
+    "## Basic Setup\n",
+    "\n",
+    "Next we will follow the tutorial and load up our dataset and tokenizer to prepocess the data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gCVrdHOVgjtH"
+   },
+   "source": [
+    "### Data Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PQ80tXFPwAnR"
+   },
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "raw_datasets = load_dataset(\"imdb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "inP62g7LwV5n"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"bert-base-cased\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "aQgWjFq1yESe"
+   },
+   "outputs": [],
+   "source": [
+    "def tokenize_function(examples):\n",
+    "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
+    "\n",
+    "tokenized_datasets = raw_datasets.map(tokenize_function, batched=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "xnLbsx2Jhurm"
+   },
+   "source": [
+    "We move towards the end of the tutorial for PyTorch specific instructions. Here we are extracting a larger subset of our original datasets. We also don't need to provide a seed since we seeded everything at the beginning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "iPQy_FMcxBy3"
+   },
+   "outputs": [],
+   "source": [
+    "tokenized_datasets = tokenized_datasets.remove_columns([\"text\"])\n",
+    "tokenized_datasets = tokenized_datasets.rename_column(\"label\", \"labels\")\n",
+    "tokenized_datasets.set_format(\"torch\")\n",
+    "\n",
+    "small_train_dataset = tokenized_datasets[\"train\"].shuffle().select(range(5000))\n",
+    "small_eval_dataset = tokenized_datasets[\"test\"].shuffle().select(range(5000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0JvnKjqRiEFP"
+   },
+   "source": [
+    "### Dataloaders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "APNr5lgsygtw"
+   },
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "train_dataloader = DataLoader(small_train_dataset, shuffle=True, batch_size=8)\n",
+    "eval_dataloader = DataLoader(small_eval_dataset, batch_size=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ax8ToOAviGGS"
+   },
+   "source": [
+    "### Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XVS15FELytIj"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoModelForSequenceClassification\n",
+    "\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(\"bert-base-cased\", num_labels=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QOI8dLDDiI7c"
+   },
+   "source": [
+    "### Optimizer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "id": "RIihFsPryvI_"
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AdamW\n",
+    "\n",
+    "optimizer = AdamW(model.parameters(), lr=5e-5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0-Yd47-UiLFs"
+   },
+   "source": [
+    "### LR Scheduler\n",
+    "\n",
+    "We will use the built-in Ignite alternative of `linear` scheduler which is [`PiecewiseLinear`](https://pytorch.org/ignite/generated/ignite.handlers.param_scheduler.PiecewiseLinear.html#piecewiselinear). We will also increase the number of epochs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "U5gBJL-uS9WG"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.contrib.handlers import PiecewiseLinear\n",
+    "\n",
+    "num_epochs = 10\n",
+    "num_training_steps = num_epochs * len(train_dataloader)\n",
+    "\n",
+    "milestones_values = [\n",
+    "        (0, 5e-5),\n",
+    "        (num_training_steps, 0.0),\n",
+    "    ]\n",
+    "lr_scheduler = PiecewiseLinear(\n",
+    "        optimizer, param_name=\"lr\", milestones_values=milestones_values\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vEPNZEO8jRSf"
+   },
+   "source": [
+    "### Set Device"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "A0WXnFD7bg2C"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "device = torch.device(\"cuda\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
+    "model.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "elcEG2gojTsI"
+   },
+   "source": [
+    "## Create Trainer\n",
+    "\n",
+    "Ignite's [`Engine`](https://pytorch.org/ignite/concepts.html#engine) allows users to define a `process_function` to process a given batch of data. This function is applied to all the batches of the dataset. This is a general class that can be applied to train and validate models. A `process_function` has two parameters `engine` and `batch`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "iVoVnJTlWau5"
+   },
+   "source": [
+    "The code for processing a batch of training data in the tutorial is as follows:\n",
+    "\n",
+    "```python\n",
+    "for batch in train_dataloader:\n",
+    "    batch = {k: v.to(device) for k, v in batch.items()}\n",
+    "    outputs = model(**batch)\n",
+    "    loss = outputs.loss\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "    lr_scheduler.step()\n",
+    "    optimizer.zero_grad()\n",
+    "    progress_bar.update(1)\n",
+    "```\n",
+    "\n",
+    "Therefore we will define a `process_function` (called `train_step` below) to do the above tasks:\n",
+    "\n",
+    "* Set `model` in train mode. \n",
+    "* Move items of the `batch` to `device`.\n",
+    "* Perform forward pass and generate `output`.\n",
+    "* Extract loss.\n",
+    "* Perform backward pass using loss to calculate gradients for the model parameters.\n",
+    "* Optimize model parameters using gradients and optimizer.\n",
+    "\n",
+    "Finally, we choose to return the `loss` so we can utilize it for futher processing.\n",
+    "\n",
+    "You will also notice that we do not update the `lr_scheduler` and `progress_bar` in `train_step`. This is because Ignite automatically takes care of it as we will see later in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "id": "Q4ncIcYcznkQ"
+   },
+   "outputs": [],
+   "source": [
+    "def train_step(engine, batch):  \n",
+    "    model.train()\n",
+    "    \n",
+    "    batch = {k: v.to(device) for k, v in batch.items()}\n",
+    "    outputs = model(**batch)\n",
+    "    loss = outputs.loss\n",
+    "    loss.backward()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "    optimizer.zero_grad()\n",
+    "\n",
+    "    return loss"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n1rXDRO4Y_dp"
+   },
+   "source": [
+    "And then we create a model `trainer` by attaching the `train_step` to the training engine. Later, we will use `trainer` for looping over the training dataset for `num_epochs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "id": "LFWgXnX4cWV1"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.engine import Engine\n",
+    "\n",
+    "trainer = Engine(train_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "U4Wx_3rrns0a"
+   },
+   "source": [
+    "The `lr_scheduler` we defined perviously was a handler. \n",
+    "\n",
+    "[Handlers](https://pytorch.org/ignite/concepts.html#handlers) can be any type of function (lambda functions, class methods, etc). On top of that, Ignite provides several built-in handlers to reduce redundant code. We attach these handlers to engine which is triggered at a specific [event](https://pytorch.org/ignite/concepts.html#events-and-handlers). These events can be anything like the start of an iteration or the end of an epoch. [Here](https://pytorch.org/ignite/generated/ignite.engine.events.Events.html#events) is a complete list of built-in events.\n",
+    "\n",
+    "Therefore, we will attach the `lr_scheduler` (handler) to the `trainer` (`engine`) via [`add_event_handler()`](https://pytorch.org/ignite/generated/ignite.engine.engine.Engine.html#ignite.engine.engine.Engine.add_event_handler) so it can be triggered at `Events.ITERATION_STARTED` (start of an iteration) automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LauRCX2Vi8Su"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.engine import Events\n",
+    "\n",
+    "trainer.add_event_handler(Events.ITERATION_STARTED, lr_scheduler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "vPXFO_3dc2ll"
+   },
+   "source": [
+    "This is the reason we did not include `lr_scheduler.step()` in `train_step()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bNSOB05LjfVB"
+   },
+   "source": [
+    "## Progress Bar\n",
+    "\n",
+    "Next we create an instance of Ignite's [`ProgessBar()`](https://pytorch.org/ignite/generated/ignite.contrib.handlers.tqdm_logger.html#ignite.contrib.handlers.tqdm_logger.ProgressBar) and attach it to the trainer to replace `progress_bar.update(1)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "id": "PxSVmnLica2c"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.contrib.handlers import ProgressBar\n",
+    "\n",
+    "pbar = ProgressBar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X9KSg4s5eLJn"
+   },
+   "source": [
+    "We can either, simply track the progress:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "id": "C7t_K2MOd6qp"
+   },
+   "outputs": [],
+   "source": [
+    "pbar.attach(trainer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sxwfbhkCeRf0"
+   },
+   "source": [
+    "Or also track the output of `trainer` (or `train_step`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "id": "Ib1uF2GHeQlt"
+   },
+   "outputs": [],
+   "source": [
+    "pbar.attach(trainer, output_transform=lambda x: {'loss': x})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Bf7_CjXvjj0K"
+   },
+   "source": [
+    "## Create Evaluator\n",
+    "\n",
+    "Similar to the training `process_function`, we setup a function to evaluate a single batch of train/validation/test data.\n",
+    "\n",
+    "```python\n",
+    "model.eval()\n",
+    "for batch in eval_dataloader:\n",
+    "    batch = {k: v.to(device) for k, v in batch.items()}\n",
+    "    with torch.no_grad():\n",
+    "        outputs = model(**batch)\n",
+    "\n",
+    "    logits = outputs.logits\n",
+    "    predictions = torch.argmax(logits, dim=-1)\n",
+    "    metric.add_batch(predictions=predictions, references=batch[\"labels\"])\n",
+    "```\n",
+    "\n",
+    " Here is what `evaluate_step()` below does:\n",
+    "\n",
+    "* Sets model in eval mode.\n",
+    "* Move items of the `batch` to `device`.\n",
+    "* With `torch.no_grad()`, no gradients are calculated for any succeding steps.\n",
+    "* Perform a forward pass on the model to calculate `outputs` from `batch`\n",
+    "* Get the real `predictions` from `logits` (probability of positive and negative classes).\n",
+    "\n",
+    "Finally, we return the predictions and the actual labels so that we can compute the metrics.\n",
+    "\n",
+    "You will notice that we did not compute the metrics in `evaluate_step()`. This is because Ignite provides built-in [metrics](https://pytorch.org/ignite/concepts.html#metrics) which we can later attach to the engine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "98H3y4xagmao"
+   },
+   "source": [
+    "**Note:** Ignite suggests attaching metrics to evaluators and not trainers because during the training the model parameters are constantly changing and it is best to evaluate model on a stationary model. This information is important as there is a difference in the functions for training and evaluating. Training returns a single scalar loss. Evaluating returns `y_pred` and `y` as that output is used to calculate metrics per batch for the entire dataset.\n",
+    "\n",
+    "All metrics in Ignite require `y_pred` and `y` as outputs of the function attached to the Engine. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "id": "H3F69ZOwcUdQ"
+   },
+   "outputs": [],
+   "source": [
+    "def evaluate_step(engine, batch):\n",
+    "    model.eval()\n",
+    "\n",
+    "    batch = {k: v.to(device) for k, v in batch.items()}\n",
+    "    with torch.no_grad():\n",
+    "        outputs = model(**batch)\n",
+    "\n",
+    "    logits = outputs.logits\n",
+    "    predictions = torch.argmax(logits, dim=-1)\n",
+    "\n",
+    "    return {'y_pred': predictions, 'y': batch[\"labels\"]}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VFrSJYx-mutP"
+   },
+   "source": [
+    "Below we create two engines, a training evaluator and a validation evaluator. `train_evaluator` and `validation_evaluator` use the same function but they serve different purposes as we will see later in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "id": "xfxf_TGadIjc"
+   },
+   "outputs": [],
+   "source": [
+    "train_evaluator = Engine(evaluate_step)\n",
+    "validation_evaluator = Engine(evaluate_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ESp1oe8jjtI6"
+   },
+   "source": [
+    "## Attach Metrics\n",
+    "\n",
+    "The 🤗 tutorial defines one metric, accuracy, to be used for evaluation:\n",
+    "\n",
+    "```python\n",
+    "metric= load_metric(\"accuracy\")\n",
+    "```\n",
+    "\n",
+    "We can easily attach Ignite's built-in [`Accuracy()`](https://pytorch.org/ignite/generated/ignite.metrics.Accuracy.html#accuracy) metric to to `train_evaluator` and `validation_evaluator`. We also need to specify the metric name (`accuracy` below). Internally, it will use `y_pred` and `y` to compute the accuracy. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "id": "RsT3Yq1sd5Os"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.metrics import Accuracy\n",
+    "\n",
+    "Accuracy().attach(train_evaluator, 'accuracy')\n",
+    "Accuracy().attach(validation_evaluator, 'accuracy')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "so6yub_fjydU"
+   },
+   "source": [
+    "## Log Metrics\n",
+    "\n",
+    "Now we will define custom handlers (functions) and attach them to various `Events` of the training process.\n",
+    "\n",
+    "The functions below both achieve similar tasks. They print the results of the `evaluator` run on a dataset. `log_training_results()` does this on the training evaluator and train dataset, while `log_validation_results()` on the validation evaluator and validation dataset. Another difference is how these functions are attached in the trainer engine.\n",
+    "\n",
+    "The first method involves using a decorator, the syntax is simple - `@` `trainer.on(Events.EPOCH_COMPLETED)`, means that the decorated function will be attached to the trainer and called at the end of each epoch. \n",
+    "\n",
+    "The second method involves using the add_event_handler method of trainer - `trainer.add_event_handler(Events.EPOCH_COMPLETED, custom_function)`. This achieves the same result as the above. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mrl-60C9aEkW"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(Events.EPOCH_COMPLETED)\n",
+    "def log_training_results(engine):\n",
+    "    train_evaluator.run(train_dataloader)\n",
+    "    metrics = train_evaluator.state.metrics\n",
+    "    avg_accuracy = metrics['accuracy']\n",
+    "    print(f\"Training Results - Epoch: {engine.state.epoch}  Avg accuracy: {avg_accuracy:.3f}\")\n",
+    "    \n",
+    "def log_validation_results(engine):\n",
+    "    validation_evaluator.run(eval_dataloader)\n",
+    "    metrics = validation_evaluator.state.metrics\n",
+    "    avg_accuracy = metrics['accuracy']\n",
+    "    print(f\"Validation Results - Epoch: {engine.state.epoch}  Avg accuracy: {avg_accuracy:.3f}\")\n",
+    "\n",
+    "trainer.add_event_handler(Events.EPOCH_COMPLETED, log_validation_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fGbSjScZj2Bt"
+   },
+   "source": [
+    "## Early Stopping\n",
+    "\n",
+    "Now we'll setup a [`EarlyStopping`](https://pytorch.org/ignite/generated/ignite.handlers.early_stopping.EarlyStopping.html#earlystopping) handler for the training process. `EarlyStopping` requires a score_function that allows the user to define whatever criteria to stop trainig. In this case, if the loss of the validation set does not decrease in 2 epochs (`patience`), the training process will stop early.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "O0xElFVYeuL9"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.handlers import EarlyStopping\n",
+    "\n",
+    "def score_function(engine):\n",
+    "    val_accuracy = engine.state.metrics['accuracy']\n",
+    "    return val_accuracy\n",
+    "\n",
+    "handler = EarlyStopping(patience=2, score_function=score_function, trainer=trainer)\n",
+    "validation_evaluator.add_event_handler(Events.COMPLETED, handler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "C1UtBUmmj9dq"
+   },
+   "source": [
+    "## Model Checkpoint\n",
+    "\n",
+    "Lastly, we want to save the best model weights. So we will use Ignite's [`ModelCheckpoint`](https://pytorch.org/ignite/generated/ignite.handlers.checkpoint.ModelCheckpoint.html#modelcheckpoint) handler to checkpoint models at the end of each epoch. This will create a `models` directory and save the 2 best models (`n_saved`) with the prefix `bert-base-cased`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7xz8qozReQuG"
+   },
+   "outputs": [],
+   "source": [
+    "from ignite.handlers import ModelCheckpoint\n",
+    "\n",
+    "checkpointer = ModelCheckpoint(dirname='models', filename_prefix='bert-base-cased', n_saved=2, create_dir=True)\n",
+    "trainer.add_event_handler(Events.EPOCH_COMPLETED, checkpointer, {'model': model})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jgzcQVfvkAXK"
+   },
+   "source": [
+    "## Begin Training!\n",
+    "\n",
+    "Next, we'll run the trainer for 10 epochs and monitor the results. Below we can see that `ProgessBar` prints the loss per iteration, and prints the results of training and validation as we specified in our custom function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "sS0Ut5z0dmQc"
+   },
+   "outputs": [],
+   "source": [
+    "trainer.run(train_dataloader, max_epochs=num_epochs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OpqXiZUsznkY"
+   },
+   "source": [
+    "That's it! We have successfully trained and evaluated a Transformer for Text Classification. "
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "transformers-text-classification.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/tutorials/intermediate/01-cifar10-distributed.ipynb
+++ b/tutorials/intermediate/01-cifar10-distributed.ipynb
@@ -1534,7 +1534,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1548,9 +1548,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/tutorials/intermediate/02-Machine_Translation_using_PyTorch_Ignite.ipynb
+++ b/tutorials/intermediate/02-Machine_Translation_using_PyTorch_Ignite.ipynb
@@ -974,7 +974,7 @@
  "metadata": {
   "accelerator": "GPU",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -988,9 +988,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/tutorials/intermediate/03-reinforcement-learning.ipynb
+++ b/tutorials/intermediate/03-reinforcement-learning.ipynb
@@ -1,799 +1,799 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "name": "reinforcement_learning.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.8.8"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "HCS-d1T3znj2"
+   },
+   "source": [
+    "<!-- ---\n",
+    "title: Reinforcement Learning with Ignite\n",
+    "date: 2021-11-22\n",
+    "downloads: true\n",
+    "weight: 3\n",
+    "tags:\n",
+    "  - RL\n",
+    "  - intermediate\n",
+    "--- -->\n",
+    "# Reinforcement Learning with Ignite"
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rjZMYxFoznj9"
+   },
+   "source": [
+    "In this tutorial we will implement a [policy gradient based algorithm](http://www.scholarpedia.org/article/Policy_gradient_methods) called [Reinforce](http://www.cs.toronto.edu/~tingwuwang/REINFORCE.pdf) and use it to solve OpenAI's [Cartpole problem](https://github.com/openai/gym/wiki/CartPole-v0) using PyTorch-Ignite.\n",
+    "<!--more--> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cT-Tnhdm5sRk"
+   },
+   "source": [
+    "## Prerequisite\n",
+    "\n",
+    "The reader should be familiar with the basic concepts of Reinforcement Learning like state, action, environment, etc."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aLCzuCbjVDoR"
+   },
+   "source": [
+    "## The Cartpole Problem\n",
+    "\n",
+    "We have to balance a Cartpole which is a pole-like structure attached to a cart. The cart is free to move across the frictionless surface. We can balance the cartpole by moving the cart left or right in 1D. Let's start by defining a few terms.\n",
+    "\n",
+    "### State\n",
+    "\n",
+    "There are 4 variables on which the environment depends: cart position and velocity, pole position and velocity.\n",
+    "\n",
+    "### Action space\n",
+    "\n",
+    "There are 2 possible actions that the agent can perform: left or right direction.\n",
+    "\n",
+    "### Reward\n",
+    "\n",
+    "For each instance of the cartpole not toppling down or going out of range, we have a reward of 1.\n",
+    "\n",
+    "### When is it solved?\n",
+    "\n",
+    "The problem is considered solved when the average reward is greater than `reward_threshold` defined for the environment.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "sovYyC0Zznj-"
+   },
+   "source": [
+    "## Required Dependencies "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "enczLgLTznkH"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install gym pytorch-ignite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2aU0KIAEcDeA"
+   },
+   "source": [
+    "### On Colab\n",
+    "\n",
+    "We need additional dependencies to render the environment on Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_oC7TJRilfoS"
+   },
+   "outputs": [],
+   "source": [
+    "!apt-get install -y xvfb python-opengl\n",
+    "!pip install pyvirtualdisplay"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EEFZUczFRm0d"
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "6ao9uGo-db8T"
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torch.optim as optim\n",
+    "from torch.distributions import Categorical\n",
+    "\n",
+    "from ignite.engine import Engine, Events\n",
+    "\n",
+    "import gym\n",
+    "from gym.wrappers import Monitor\n",
+    "\n",
+    "import glob\n",
+    "import io\n",
+    "import base64\n",
+    "from IPython.display import HTML\n",
+    "from IPython import display as ipythondisplay\n",
+    "from pyvirtualdisplay import Display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gT9ro74aTVUf"
+   },
+   "source": [
+    "## Configurable Parameters\n",
+    "\n",
+    "We will use there values later in the tutorial at appropriate places."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "biK79K4_MupY"
+   },
+   "outputs": [],
+   "source": [
+    "seed_val = 543\n",
+    "gamma = 0.99\n",
+    "log_interval = 100\n",
+    "max_episodes = 1000000\n",
+    "render = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9Zux1Dv5Tchc"
+   },
+   "source": [
+    "## Setting up the Environment\n",
+    "\n",
+    "Let's load our environment first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eTfYSODJTbux"
+   },
+   "outputs": [],
+   "source": [
+    "env = gym.make(\"CartPole-v0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "afRSrabwTq_a"
+   },
+   "source": [
+    "### On Colab\n",
+    "\n",
+    "If on Google Colab, we need to follow a list of steps to render the output. First we initialize our screen size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "HbhZwa-JM7ub",
+    "outputId": "223bdc5b-a057-40ee-8278-522ec1d9184b"
+   },
+   "outputs": [
     {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "HCS-d1T3znj2"
-      },
-      "source": [
-        "<!-- ---\n",
-        "title: Reinforcement Learning with Ignite\n",
-        "date: 2021-11-22\n",
-        "downloads: true\n",
-        "weight: 3\n",
-        "tags:\n",
-        "  - RL\n",
-        "  - intermediate\n",
-        "--- -->\n",
-        "# Reinforcement Learning with Ignite"
+     "data": {
+      "text/plain": [
+       "<pyvirtualdisplay.display.Display at 0x7f76f00bf810>"
       ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rjZMYxFoznj9"
-      },
-      "source": [
-        "In this tutorial we will implement a [policy gradient based algorithm](http://www.scholarpedia.org/article/Policy_gradient_methods) called [Reinforce](http://www.cs.toronto.edu/~tingwuwang/REINFORCE.pdf) and use it to solve OpenAI's [Cartpole problem](https://github.com/openai/gym/wiki/CartPole-v0) using PyTorch-Ignite.\n",
-        "<!--more--> "
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "cT-Tnhdm5sRk"
-      },
-      "source": [
-        "## Prerequisite\n",
-        "\n",
-        "The reader should be familiar with the basic concepts of Reinforcement Learning like state, action, environment, etc."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "aLCzuCbjVDoR"
-      },
-      "source": [
-        "## The Cartpole Problem\n",
-        "\n",
-        "We have to balance a Cartpole which is a pole-like structure attached to a cart. The cart is free to move across the frictionless surface. We can balance the cartpole by moving the cart left or right in 1D. Let's start by defining a few terms.\n",
-        "\n",
-        "### State\n",
-        "\n",
-        "There are 4 variables on which the environment depends: cart position and velocity, pole position and velocity.\n",
-        "\n",
-        "### Action space\n",
-        "\n",
-        "There are 2 possible actions that the agent can perform: left or right direction.\n",
-        "\n",
-        "### Reward\n",
-        "\n",
-        "For each instance of the cartpole not toppling down or going out of range, we have a reward of 1.\n",
-        "\n",
-        "### When is it solved?\n",
-        "\n",
-        "The problem is considered solved when the average reward is greater than `reward_threshold` defined for the environment.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "sovYyC0Zznj-"
-      },
-      "source": [
-        "## Required Dependencies "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "enczLgLTznkH"
-      },
-      "source": [
-        "!pip install gym pytorch-ignite"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "2aU0KIAEcDeA"
-      },
-      "source": [
-        "### On Colab\n",
-        "\n",
-        "We need additional dependencies to render the environment on Google Colab."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "_oC7TJRilfoS"
-      },
-      "source": [
-        "!apt-get install -y xvfb python-opengl\n",
-        "!pip install pyvirtualdisplay"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EEFZUczFRm0d"
-      },
-      "source": [
-        "## Imports"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "6ao9uGo-db8T"
-      },
-      "source": [
-        "import numpy as np\n",
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torch.nn.functional as F\n",
-        "import torch.optim as optim\n",
-        "from torch.distributions import Categorical\n",
-        "\n",
-        "from ignite.engine import Engine, Events\n",
-        "\n",
-        "import gym\n",
-        "from gym.wrappers import Monitor\n",
-        "\n",
-        "import glob\n",
-        "import io\n",
-        "import base64\n",
-        "from IPython.display import HTML\n",
-        "from IPython import display as ipythondisplay\n",
-        "from pyvirtualdisplay import Display"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gT9ro74aTVUf"
-      },
-      "source": [
-        "## Configurable Parameters\n",
-        "\n",
-        "We will use there values later in the tutorial at appropriate places."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "biK79K4_MupY"
-      },
-      "source": [
-        "seed_val = 543\n",
-        "gamma = 0.99\n",
-        "log_interval = 100\n",
-        "max_episodes = 1000000\n",
-        "render = True"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9Zux1Dv5Tchc"
-      },
-      "source": [
-        "## Setting up the Environment\n",
-        "\n",
-        "Let's load our environment first."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "eTfYSODJTbux"
-      },
-      "source": [
-        "env = gym.make(\"CartPole-v0\")"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "afRSrabwTq_a"
-      },
-      "source": [
-        "### On Colab\n",
-        "\n",
-        "If on Google Colab, we need to follow a list of steps to render the output. First we initialize our screen size."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "HbhZwa-JM7ub",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "223bdc5b-a057-40ee-8278-522ec1d9184b"
-      },
-      "source": [
-        "display = Display(visible=0, size=(1400, 900))\n",
-        "display.start()"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<pyvirtualdisplay.display.Display at 0x7f76f00bf810>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 6
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "l8qDfZi_R2xW"
-      },
-      "source": [
-        "Below we have a utility function to enable video recording of the gym environment. To enable video, we have to wrap our environment in this function."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "V2bZH987tHtT"
-      },
-      "source": [
-        "def wrap_env(env):\n",
-        "  env = Monitor(env, './video', force=True)\n",
-        "  return env\n",
-        "\n",
-        "env = wrap_env(env)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "_iOU0i6sUg9D"
-      },
-      "source": [
-        "### Set the seed"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "rQljT2b2k1Qy",
-        "outputId": "dfaa0eeb-e1c7-46c5-a266-a06b508229aa"
-      },
-      "source": [
-        "env.seed(seed_val)\n",
-        "torch.manual_seed(seed_val)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "<torch._C.Generator at 0x7f76fa684730>"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 8
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ax8ToOAviGGS"
-      },
-      "source": [
-        "## Model\n",
-        "\n",
-        "We are going to utilize the reinforce algorithm in which our agent will use episode samples from starting state to goal state directly from the environment. Our model has two linear layers with 4 in features and 2 out features for 4 state variables and 2 actions respectively. We also define an action buffer as `saved_log_probs` and a rewards one. We also have an intermediate ReLU layer through which the outputs of the 1st layer are passed to receive the score for each action taken. Finally, we return a list of probabilities for each of these actions.\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "XVS15FELytIj"
-      },
-      "source": [
-        "class Policy(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super(Policy, self).__init__()\n",
-        "        self.affine1 = nn.Linear(4, 128)\n",
-        "        self.affine2 = nn.Linear(128, 2)\n",
-        "\n",
-        "        self.saved_log_probs = []\n",
-        "        self.rewards = []\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        x = F.relu(self.affine1(x))\n",
-        "        action_scores = self.affine2(x)\n",
-        "        return F.softmax(action_scores, dim=1)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "dAKv4jUmrnbj"
-      },
-      "source": [
-        "And then we initialize our model, optimizer, epsilon and timesteps.\n",
-        "> TimeStep is the object which contains information about a state like current observation, type of the step, reward, and discount. Given that some action is performed on some state, it gives the new state, type of the new step (or state), discount, and reward achieved."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "J1Hb2LQveKR6"
-      },
-      "source": [
-        "model = Policy()\n",
-        "optimizer = optim.Adam(model.parameters(), lr=1e-2)\n",
-        "eps = np.finfo(np.float32).eps.item()\n",
-        "timesteps = list(range(10000))"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "elcEG2gojTsI"
-      },
-      "source": [
-        "## Create Trainer\n",
-        "\n",
-        "Ignite's [`Engine`](https://pytorch.org/ignite/concepts.html#engine) allows users to define a `process_function` to run one episode. We select an action from the policy, then take the action through `step()` and finally increment our reward. If the problem is solved, we terminate training and save the `timestep`.\n",
-        "\n",
-        "> An episode is an instance of a game (or life of a game). If the game ends or life decreases, the episode ends. Step, on the other hand, is the time or some discrete value which increases monotonically in an episode. With each change in the state of the game, the value of step increases until the game ends."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Q4ncIcYcznkQ"
-      },
-      "source": [
-        "def run_single_timestep(engine, timestep):\n",
-        "    observation = engine.state.observation\n",
-        "    action = select_action(model, observation)\n",
-        "    engine.state.observation, reward, done, _ = env.step(action)\n",
-        "    if render:\n",
-        "        env.render()\n",
-        "\n",
-        "    model.rewards.append(reward)\n",
-        "\n",
-        "    if done:\n",
-        "        engine.terminate_epoch()\n",
-        "        engine.state.timestep = timestep\n",
-        "\n",
-        "trainer = Engine(run_single_timestep)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "MfHpIGCEpk0Q"
-      },
-      "source": [
-        "Next we need to select an action to take. After we get a list of probabilities, we create a categorical distribution over them and sample an action from that. This is then saved to the action buffer and the action to take is returned (left or right)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "B2xxebxhd9J8"
-      },
-      "source": [
-        "def select_action(model, observation):\n",
-        "    state = torch.from_numpy(observation).float().unsqueeze(0)\n",
-        "    probs = model(state)\n",
-        "    m = Categorical(probs)\n",
-        "    action = m.sample()\n",
-        "    model.saved_log_probs.append(m.log_prob(action))\n",
-        "    return action.item()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WV6he1cvuFcw"
-      },
-      "source": [
-        "We initialize a list to save policy loss and true returns of the rewards returned from the environment. Then we calculate the policy losses from the advantage (`-log_prob * reward`). Finally, we reset the gradients, perform backprop on the policy loss and reset the rewards and actions buffer."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "y8pctWff5Ev6"
-      },
-      "source": [
-        "def finish_episode(model, optimizer, gamma, eps):\n",
-        "    R = 0\n",
-        "    policy_loss = []\n",
-        "    rewards = []\n",
-        "    for r in model.rewards[::-1]:\n",
-        "        R = r + gamma * R\n",
-        "        rewards.insert(0, R)\n",
-        "\n",
-        "    rewards = torch.tensor(rewards)\n",
-        "    rewards = (rewards - rewards.mean()) / (rewards.std() + eps)\n",
-        "    \n",
-        "    for log_prob, reward in zip(model.saved_log_probs, rewards):\n",
-        "        policy_loss.append(-log_prob * reward)\n",
-        "\n",
-        "    optimizer.zero_grad()\n",
-        "    policy_loss = torch.cat(policy_loss).sum()\n",
-        "    policy_loss.backward()\n",
-        "    optimizer.step()\n",
-        "\n",
-        "    del model.rewards[:]\n",
-        "    del model.saved_log_probs[:]"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "UwuJs3n4tEe9"
-      },
-      "source": [
-        "## Attach handlers to run on specific events"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pPiGVM8FwRSC"
-      },
-      "source": [
-        "We rename the start and end epoch events for easy understanding."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "2K19lOcPeFF4"
-      },
-      "source": [
-        "EPISODE_STARTED = Events.EPOCH_STARTED\n",
-        "EPISODE_COMPLETED = Events.EPOCH_COMPLETED"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "igNnguT3wWqu"
-      },
-      "source": [
-        "Before training begins, we initialize the reward in `trainer`'s state."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "QNoGCUe9j6EF"
-      },
-      "source": [
-        "@trainer.on(Events.STARTED)\n",
-        "def initialize(engine):\n",
-        "    engine.state.running_reward = 10"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "yB-tEz9awzoj"
-      },
-      "source": [
-        "When an episode begins, we have to reset the environment's state."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "nN3P6Zq6wVo_"
-      },
-      "source": [
-        "@trainer.on(EPISODE_STARTED)\n",
-        "def reset_environment_state(engine):\n",
-        "    engine.state.observation = env.reset()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "NvTZVIAzxOCh"
-      },
-      "source": [
-        "When an episode finishes, we update the running reward and perform backpropogation by calling `finish_episode()`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "wVEZBDeAUAwy"
-      },
-      "source": [
-        "@trainer.on(EPISODE_COMPLETED)\n",
-        "def update_model(engine):\n",
-        "    t = engine.state.timestep\n",
-        "    engine.state.running_reward = engine.state.running_reward * 0.99 + t * 0.01\n",
-        "    finish_episode(model, optimizer, gamma, eps)"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pJV6beL4xf10"
-      },
-      "source": [
-        "After that, every 100 (`log_interval`) episodes, we log the results."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "r1EvA2qJUFb6"
-      },
-      "source": [
-        "@trainer.on(EPISODE_COMPLETED(every=log_interval))\n",
-        "def log_episode(engine):\n",
-        "    i_episode = engine.state.epoch\n",
-        "    print(\n",
-        "        f\"Episode {i_episode}\\tLast length: {engine.state.timestep:5d}\"\n",
-        "        f\"\\tAverage length: {engine.state.running_reward:.2f}\"\n",
-        "    )"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Kfa3fHTqxl2A"
-      },
-      "source": [
-        "And finally, we check if our running reward has crossed the threshold so that we can stop training."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "rzdhbUxSUHmk"
-      },
-      "source": [
-        "@trainer.on(EPISODE_COMPLETED)\n",
-        "def should_finish_training(engine):\n",
-        "    running_reward = engine.state.running_reward\n",
-        "    if running_reward > env.spec.reward_threshold:\n",
-        "        print(\n",
-        "            f\"Solved! Running reward is now {running_reward} and \"\n",
-        "            f\"the last episode runs to {engine.state.timestep} time steps!\"\n",
-        "        )\n",
-        "        engine.should_terminate = True"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "kpU3b8ymtPCD"
-      },
-      "source": [
-        "## Run Trainer"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "jjNcMaLkks8M",
-        "outputId": "492f1c2d-a735-45b3-cee2-f599b5717f05"
-      },
-      "source": [
-        "trainer.run(timesteps, max_epochs=max_episodes)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Episode 100\tLast length:    66\tAverage length: 37.90\n",
-            "Episode 200\tLast length:    21\tAverage length: 115.82\n",
-            "Episode 300\tLast length:   199\tAverage length: 133.13\n",
-            "Episode 400\tLast length:    98\tAverage length: 134.97\n",
-            "Episode 500\tLast length:    77\tAverage length: 77.39\n",
-            "Episode 600\tLast length:   199\tAverage length: 132.99\n",
-            "Episode 700\tLast length:   122\tAverage length: 137.40\n",
-            "Episode 800\tLast length:    39\tAverage length: 159.51\n",
-            "Episode 900\tLast length:    86\tAverage length: 113.31\n",
-            "Episode 1000\tLast length:    76\tAverage length: 114.67\n",
-            "Episode 1100\tLast length:    96\tAverage length: 98.65\n",
-            "Episode 1200\tLast length:    90\tAverage length: 84.50\n",
-            "Episode 1300\tLast length:   102\tAverage length: 89.10\n",
-            "Episode 1400\tLast length:    64\tAverage length: 86.45\n",
-            "Episode 1500\tLast length:    60\tAverage length: 76.35\n",
-            "Episode 1600\tLast length:    75\tAverage length: 71.38\n",
-            "Episode 1700\tLast length:   176\tAverage length: 117.25\n",
-            "Episode 1800\tLast length:   139\tAverage length: 140.96\n",
-            "Episode 1900\tLast length:    63\tAverage length: 141.79\n",
-            "Episode 2000\tLast length:    66\tAverage length: 94.01\n",
-            "Episode 2100\tLast length:   199\tAverage length: 115.46\n",
-            "Episode 2200\tLast length:   113\tAverage length: 137.11\n",
-            "Episode 2300\tLast length:   174\tAverage length: 135.36\n",
-            "Episode 2400\tLast length:    80\tAverage length: 116.46\n",
-            "Episode 2500\tLast length:    96\tAverage length: 101.47\n",
-            "Episode 2600\tLast length:   199\tAverage length: 141.13\n",
-            "Episode 2700\tLast length:    13\tAverage length: 134.91\n",
-            "Episode 2800\tLast length:    90\tAverage length: 71.22\n",
-            "Episode 2900\tLast length:    61\tAverage length: 70.14\n",
-            "Episode 3000\tLast length:   199\tAverage length: 129.67\n",
-            "Episode 3100\tLast length:   199\tAverage length: 173.62\n",
-            "Episode 3200\tLast length:   199\tAverage length: 189.30\n",
-            "Solved! Running reward is now 195.03268327777783 and the last episode runs to 199 time steps!\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "State:\n",
-              "\titeration: 396569\n",
-              "\tepoch: 3289\n",
-              "\tepoch_length: 10000\n",
-              "\tmax_epochs: 1000000\n",
-              "\toutput: <class 'NoneType'>\n",
-              "\tbatch: 199\n",
-              "\tmetrics: <class 'dict'>\n",
-              "\tdataloader: <class 'list'>\n",
-              "\tseed: <class 'NoneType'>\n",
-              "\ttimes: <class 'dict'>\n",
-              "\trunning_reward: 195.03268327777783\n",
-              "\tobservation: <class 'numpy.ndarray'>\n",
-              "\ttimestep: 199"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 19
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "lVSKBkaMSO2g"
-      },
-      "source": [
-        "env.close()"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Z8_G4PK8SRvX"
-      },
-      "source": [
-        "### On Colab\n",
-        "\n",
-        "Finally, we can view our saved video."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 421
-        },
-        "id": "wRkNUrpQt6P6",
-        "outputId": "a2b1163c-5e9c-49d4-ce2e-d62424cdd0bb"
-      },
-      "source": [
-        "mp4list = glob.glob('video/*.mp4')\n",
-        "\n",
-        "if len(mp4list) > 0:\n",
-        "    mp4 = mp4list[0]\n",
-        "    video = io.open(mp4, 'r+b').read()\n",
-        "    encoded = base64.b64encode(video)\n",
-        "    ipythondisplay.display(HTML(data='''<video alt=\"test\" autoplay \n",
-        "                loop controls style=\"height: 400px;\">\n",
-        "                <source src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\" />\n",
-        "              </video>'''.format(encoded.decode('ascii'))))\n",
-        "else: \n",
-        "    print(\"Could not find video\")"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/html": [
-              "<video alt=\"test\" autoplay \n",
-              "                loop controls style=\"height: 400px;\">\n",
-              "                <source src=\"data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAPMVtZGF0AAACrgYF//+q3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE1MiByMjg1NCBlOWE1OTAzIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAxNyAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTMgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTQwIGludHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4wMACAAAABo2WIhAAz//727L4FNf2f0JcRLMXaSnA+KqSAgHc0wAAAAwAAAwAAFgn0I7DkqgN3QAAAHGAFBCwCPCVC2EhH2OkN/weGVAAoD+Tf/UBEHTHT5d/yQiZHO4sg6+zQfs3HI2Y6XZYIRxBm5Rlw5hOCDQtMmgo2zuuFRyAkCAT+9j690O9LdX0vkvSqb33AZdOYYH7qaRR/tss5WLh8ulT532CFFEYvMzRgs0s8puGOPMhBR0ZjRCW8Z0rqEtwcL9cej4Tk0hBdUxtF6hnpsebLADA8EaUwpllZJh1QzIU7mYScNFckSg8ukbIRgWC1k53wt0SdRltJf2UgmeZjrPUL+px4bsCwAANsDZb3yTd4pfYTs10+T+Bo5uRJ/KzPNL/Dl8z0NKih4yPyuG6fePzY78gELZMKQ27ehFW31ciOsjpztaP2rVHecHBjejCGd0wzUpD/u6OqxJqdL87mtINCCr8neNMoDC9WvVXKyTBKAFCrxEQfLcU8HTRE3Ck5zf2gVRQHUh/T7+0L+3yetgpnZIGCACZrLQx6+QD2QAAAAwAAAwFjAAAArEGaJGxDP/6eEAAARVIuQCa1e8Eic9WotG35y8Q22j4UouROtaSMnaJLdLavH2fycnWQPwrafbUfl48e41mxkGK3Qt9e8wwm35F6tDBYIiI/koi0C8FMYJ3g7ukfZJYhve/Kb766Dv34568eUzLhIrKYYmLUg4T6aE+s4Jjtd7byju4MjPErcjhiX9+CF436E01SsTSpDYACP0RX9n/UOI6Vkhw7CQurLEoh7bAAAABWQZ5CeIR/AAAWtVlaQAKTPCg0DVgYqXZ6OIpzjPnX2+y1JZ4MgCJlIme0nlmZTkDBfp3Ct7I5ZUXzGRX4hWo6EVGpt2NvYHRchgAAAwFxQA94rFGuhvUAAAAzAZ5hdEf/AAAjrD5s3sFKk+VnV4vXc7FzsfQ5Lnj8WFT8AAADAAADAAwSiXjxUBVUr4eAAAAANAGeY2pH/wAADYKPU6xylyxViQ+s11+cJeAD+W5v72eOFilaROEiKNBlfKAAAEfhWNYQEjEAAAChQZpoSahBaJlMCGf//p4QAABFaPF1IfbdaPFByIflDUWEq1zqY70u+RQhPS4fY3dh3MIR1IGmhhqoCOE4XbCWcqgilvFr0SvIZP+sJEhPzcV8p8ny+s3etVL3MlrbXWl/x27jypNHnIwBFEh+m5q0CGn3fsSDtN/dR4voXp7WHcbGDxyTJ7atLcKIbna2TarfFZMps87XtF5JM7kZdKZ6OxEAAABAQZ6GRREsI/8AABa1WLR4pbUi6N8osAHAXCQghsP4oJQnAQgtiyImWnIg7CqjmJj9Bx+rurfZ9OoF2cKedW8JOQAAACkBnqV0R/8AACPDO/XhaOun9ZGzdLnuaJyOWHHYOJ+ApwfC6PNlg/4DUwAAACMBnqdqR/8AAA2CMPxFtfwu6fCj0PCnH892M3Ww0RAFDCAu4AAAAJpBmqxJqEFsmUwIX//+jLAAABqh8jIkAZs/FJj8RPb9jF68sePFRWvgjrAgrgK4WzA9bJta/jdj4s2BJ62oA0e6/oZVHQ9yNBMN/R869//M0EF+GsnMUdYapNj/1e50skXttNN4BTT8fcfmRgRQcLDpWG8tbTGxebdyWRIoQGO2g+r1EpoS6bQXTTnWN9VvSAaf4AwSbN1A4EFAAAAAP0GeykUVLCP/AAAIcIWMZl6CnOqysvZock1EQY1v5LuFPp4FMALUilvLiPr853Ne64RhgUJFrKX868XkqbGc+QAAACkBnul0R/8AAA1/RQ0pJAKSzGxaeBBblT2kMyYHDj7J6J/anq/5HdAi4AAAACQBnutqR/8AAA2FkDFmbJNfw8hbwYb4bxJjMHbPjMdnUlKYyoAAAAA+QZrwSahBbJlMCF///oywAAAaD+WNCcfaei2OHtsxniP2CcBX9ceVhjq1yqBlJDPK88i4uVY0ktc3zgW5jAkAAAA8QZ8ORRUsI/8AAAMDOWQNB5ognlJkCHa8mQEAlTEHhjpDgFC30Masci/YPgAkn6qGM/pdYfhlXCbOU/thAAAAMAGfLXRH/wAABPpwJbdm0rJGu5QkGeW5dLkgAH7dBYFs/8LpfnDU2e1X7uVGCxChMQAAACwBny9qR/8AAAUeWLkQP8llceZYccYBr6XAqNABMwuf/8T0Cw+q3TpuUaMHgAAAAIJBmzRJqEFsmUwIX//+jLAAAEYkG7G0BnwB65nwYZqk0zxZzEDIcop2YEhhQQRExJdgZm1WbgXGu1m2fxxSQ0h618RJxg3AX7zBiMpywLofU6KaqAzone74CtjdxpGTDvut9GncjWouu16xTy6LbIZajQBW1pWJ5j2kgvLTNP+rEs+YAAAARkGfUkUVLCP/AAAWp0JTlAAcba7OehKVjYO5ncvDZ2sVDfZfmVtbLikcLsMhr3foT7dulVc6e785F2AfvPVz+WzOkHKJ/+kAAAAfAZ9xdEf/AAAjq/houCzvaW5zUHF9NidozPU0VcsKmAAAADQBn3NqR/8AACOxzA1eLPEjwmjm4t/aW7ZnPM5nCp/K8p++AEr6D9z7oeTE/X/sHE7QLfIwAAAAbEGbdkmoQWyZTBRML//+jLAAABqtZ6e4J4AhP4hY/Gx+sO6dl9Y9pro88SpLj3SSbhj7b1oz4XqKVUswQLppqcKkd803s2XSnhrxOITuT1B6of4lx3qRKe22OpE+WLqweh/XVrD+VjYZPr5TAwAAADkBn5VqR/8AAA2AvAgAuolaIfmqm1hJ0iCoknMbEBnyAyCgnKp5TSHOV6Wpf0iXv9TKTwR4ccyTdswAAAA+QZuXSeEKUmUwIZ/+nhAAAEVFh6QAcm0KK9NMuQgBM8paQJwI7rv3NUrzngueAf4N9RAhW5UqtoDqv/1d3H0AAABXQZu7SeEOiZTAhn/+nhAAAEVFJZT8GIBmaHadINjiXnR+0qhTismpq6Gy7JVH011L+fgKMslabJt9mTgDtub25XH1acfjlZaIvPa0CLaDzoQKc14V6oMrAAAAO0Gf2UURPCP/AAAWwFoFgOX9xG9C9xtkJ21LfVeoMTnh8Yi+qiAy2QFUjr4UVMbKYN/znTYg7+3dGwUfAAAAIgGf+HRH/wAAI8M5bEd4dauJ1RIpNZxXWdc1eJNbg0wajukAAAAyAZ/6akf/AAAjvwQn2/7N1idiIA+x2LC/5RtwWLJvO9NAAPwrkYxrfvtmB6Z9vQRj44AAAABEQZv/SahBaJlMCGf//p4QAABFUQ4vBTca+16bh9YLJ5yWvP9+17gqBXEqwH8yO/hwwMbp2hOpQmsAGlS5XLaTPxePlTEAAABFQZ4dRREsI/8AABa7lD5e8OfcJ6P3Y6crmBr+QTiMs3gpUje3dMEIsjtMAC6gujf2sVXD20LDYzvHHazOXby2P2rUttsxAAAAKgGePHRH/wAAI8MXZCx3tSK11UPCCVvoog1+/rXsEiOjbbvbqYZcFejkgAAAADYBnj5qR/8AACO/Gm3MM157C6QZuPbjtpquVRiJGjQjYPCM/5QAmTPy713Qv72VHYCuuOXv23AAAABiQZojSahBbJlMCF///oywAABGAjRyAC/d5fW6FrcAU8rUOJjKQZ6cIbGLx3zUeG4FniOC59p7fMohH7CFwmViw9cZjZCrFBcGRRq3FjMqe51nYzc3pBR0uhRHFqDXqg28UfcAAABAQZ5BRRUsI/8AABbAWgIHK2fnA/faWtQAw7g7aceKhaA4chN1+tENnwANhvKg2TP1gKiSQwiOCg4o3cOiJbm/BgAAADEBnmB0R/8AACK39g73qr0yH7R97n91TccMDO9CUJpiXXi/fgAS/ufl0dOntmfEcduBAAAATwGeYmpH/wAAI8cynvkueFTwRG05bYAFnE30b3x1Y6IZLmXYaBQNVA/eUg4z3j35a76lZxbzYH+54FNdw/lWB8o3T9NsEv0oxQ7GzifY3gwAAABMQZpnSahBbJlMCF///oywAABGFEFWGR+wQFBP/b6aHgfsOjSVqI+S0PYZINJjuVLsF4egqEB4FPOZt0UZ/lYBQCjUCzVcCaenFmHFgQAAACxBnoVFFSwj/wAAFrMrtQW5HIHyD6jH2R1xoA4YxPLqDzIsUjNu2hJ/KC1bZwAAAE0BnqR0R/8AACOsORx+AFvErPdR6k1zIzgHFkw3rTJI+LTexxIO6wBVNYGfh1Ps6ISioUjKMpFZac4zCG98+M2/+KfEkCJyZjdk75z7ZwAAADQBnqZqR/8AACOyK2H4Abrl29x2R75pNsuCNWPUZsMorEx+jO6m6uUhDAFTXH9W3A2KD/BhAAAAdEGaq0moQWyZTAhf//6MsAAARnpvPcOkWABf7ajIJmRjcbvtckIIJfEDpPzLBUfn0vmUyZjL2YgCrX91mQtKAOmeXtGIn76lkcmweh9xRI6Vgcah/ANxinDlTn3RjXHyQHUTAr+jo1+chugF/RkTXBi6XSTcAAAASEGeyUUVLCP/AAAWu5xRlb+TC22oT4ipg+WKevONPgkNibOWap9tK51xb9ncKCnqlUq7+aTgEhrUrhuRpnsp+tJJcr2zuJ6W3AAAAFcBnuh0R/8AACPAuIaDOtHQA4LYGmzhQhC+Ihfa9RmFZ59ffPj9Fm5ldhbEUvvVuFFhmzhHS54TIREV5BYxsKLxjgHI/1Gtl4rhio8HQ9UqTAc6vcUOds0AAABXAZ7qakf/AAAjscENx2ivRYAAIetMlsMQzifvGsgRyb7nlcsUekqF1GXonb9fwxBDFct0rh8KdiJ04UZOTF0EbDuWz8VxTIVmzfgixZJOhcDqn/Z8XxeDAAAAWUGa7EmoQWyZTAhf//6MsAAARBRBXNXya/5+gPZoihjRO0r62s9mvzAu6isD1spjkv5TCYs1BE3sW+pEHVd/Kcl4IL8dW7xo9ecR2FCHliDJJucw8A6FCO9CAAAAPkGbD0nhClJlMCF//oywAABEAgX8xvm9ynoPdp2fiZ8FIoIARm3OqxZD/TaxtThxq/r+rEctLcc6Hxv/asGBAAAAV0GfLUU0TCP/AAAWMFoQZ4XQQAlpnXj/y/tTIwpFrgT9gAxTP2lhTLWdK7P2mqbh9vB4eH5v49RaIQDiDMNTy+VMpjlZ+GlKp14sHp0cwalgripxCU+FtwAAAEEBn05qR/8AACK9ln67sI7A/RQAWcTgBzjo/LozJGuM9mahaLHDH0TFvbNKCi3ZnkL4f9whCxV4ll/jwo36GVZSAwAAAElBm1JJqEFomUwIZ//+nhAAAENEanOn5fKByFcKjkkHK0UP0z12ACyFoVidY8ttnUjpTfhmCcNu0wNPnVwtx5phctURqrgrSfrCAAAAR0GfcEURLCP/AAAWMEaSExwiDDTOESbHe0gIrkAH1kF5SBzxJE5ZO1ipPRAIYf0bYMtvDNR0oCtlvSOx02WnVFJVEkAUAVGAAAAAOgGfkWpH/wAAIr2Wfruwjpiz3wAWQl4efX2x/xx7mWCYQRLA8NperpYsCfUhjDejKVtpaDI/ebXxck0AAABUQZuWSahBbJlMCGf//p4QAABDZAbY5EAZx11XFCqqzNy5BMhtGa2/st1QOtRNDE5UbzavElO0gI7BKmt8GfpDo7/9Xw4FkLfss0BWatJBvNXX86XwAAAASUGftEUVLCP/AAAWMDAnhAAunghCHWOpCzkpX+PLj3xUA0/BkVbj0XfG3UV6UYaw6ucIis0m5r5vD5fXmt0mA+01xI1kix4y8oAAAAA5AZ/TdEf/AAAiwLj6hQEWgAW8ASAZwvJ942AMTgcGUJnwARd33QGkz2RllMIdKi/am2W2RD50tfzBAAAASwGf1WpH/wAAIscLQKo4zTlvyAAEtRtXm90O60spdzmjt+MCxhns4Y5CBRWea9NSi3W+EDK0jhohBNwvEqPCSdid2Ryxk93Fp1smwAAAAFRBm9pJqEFsmUwIZ//+nhAAAENDlwPFphrdoiM0lmIUyMwuEbfe9AALpTUOsZgtwx8POYNJYcQskskhSLZronz5UWDh71+lv72iZSuFDzYAf4Fz3dcAAABJQZ/4RRUsI/8AABYinqi0PNMwkOUyZjJPOsZgY28g48A5ZkwEH189tnu26PzMmutmU1GYdpE/t2ripeGq/3o2W1Utwj3+xxbegQAAAEMBnhd0R/8AACGsQkV/CAAtRGVQhHEA8ydWL74bDE4cZPg6XKs7/0YekR8/Ryt8rQncct3Kpopa4c6NNH7w/k1Xw+9AAAAAOwGeGWpH/wAAIq4xL9F5PEboAFxrCJLQ/SZZbD0G/qMBQAGQFYjKsqg5SjpSKhDv7j8X3Oc1Qq7aq+k3AAAAZkGaHkmoQWyZTAhf//6MsAAARBROd+y4VLj6/Sl+mPaBvxABbwMI7Ax2B+7fjfwmw3MGCOOhElvuAUGRzqh69k/QRi79SLoVyapmal6SdsC0M61eK5KYVBj6wk4nhpl+jbjHn1lEMAAAAD1BnjxFFSwj/wAAFiKe3jcbRnjlBfKuQrrjNIvNbLycw2neenQH+1xFMxSUYAOTvnK2tvCfBz3Ao7lSPOmBAAAANAGeW3RH/wAAIaxCVOvwAturuHugehKhEoSugMB6pKKF5mQ2z43WEI/2SBHwqydX5hqMqq0AAABBAZ5dakf/AAAirjEv0XlFIKToDeGcAEqFUSo18QBXMnE/32FDOGy/GHHN+lw3jq7f/sHCSUq3i6kltb7fIe6g8EAAAABjQZpCSahBbJlMCF///oywAABEem8/3Gk2MAI96kjuYLS8nHpskEzsQngV3xYe1xV2cNDx+Y5pQgKkDcBSbPjT/OXmAKKrdGE3bzPdlb3zrAE2QlJ26U0hGxqHwti1wOd1vuewAAAAKEGeYEUVLCP/AAAWIp7eNxtHC/l0Ng8oFgZI48BsGI93UUxapZEs1vUAAAAiAZ6fdEf/AAAirBUOC8gZ6PMk+s6SEMT7qtoNP7BlxqMzwQAAACIBnoFqR/8AACKxwQ3H44sHHjGbdxd+TBpW8tBfKoAgGbghAAAAT0GahUmoQWyZTAhf//6MsAAAQhROeTV8krt/gV8ihG9UOuzQRYUSAAh8rR2ueDsckiuOdvAxDcEYmbMAcyZrpm79p2jB6zNfESyE6G3RO0AAAABBQZ6jRRUsI/8AABWSn02wiHQrpPCAyf6o46vXI7aAFSkwlz11+u+BU1pMIfZ8w/EJ8uErlH9VManvSNpfmL+dJsEAAAA5AZ7Eakf/AAAhrjL6/HB0CmwfAAuf3b6xVcUDsEY4q6qNpeFOu8FAe5W6zUg7mbYkVHrNznZvfkLBAAAAY0Gax0moQWyZTBRMM//+nhAAAEFEanSVS6uQAWlC7lDn3LtaH+5hmv6TuYBBfZY3zVGfsNRmODJqws4t9CWaZpu938nDxrP73GAl96s3ZsLNwSF+gOE4DFCgGMJ1NZ0DC5gTTwAAADsBnuZqR/8AACGuM0L+7dCTPaKAC4n9MJhv3LUkQe+AkdtUKTRCiJfPQUfUaRSV7Nx1sL5h+nFFqGsyoQAAAFZBmutJ4QpSZTAhf/6MsAAAQgD4YMAOket8AByu/PcyQ6+/3mrBhwbpuaIVX6EOPeAg/ZG6GX3sq4+ZPfqAt+QuhlmzRp0opXhzpQktdjo74Gzpd3bt7AAAADpBnwlFNEwj/wAAFZKe3jcbRwbjQSyuq0HWRpmyDtwv9sIkZKV3jNaHyUsyIxwPZIqBRrHgxN2XJaHbAAAAMwGfKHRH/wAAIanPZ2q1ZU9mmYYsRj0RftsHuyVnr0bG2ACcM+dOzZJxeEx+jak/HmshFQAAACwBnypqR/8AACGuMS/ReUPCfv+Wqawnx0rNMygBLC11nc8VX8TuH9wb8eBdxwAAAHFBmy5JqEFomUwIZ//+nhAAAEFEd8WQACq4P+WOjjjcGHJXIk8OKxhuXTK69CWDvv/9NpfZKxY8SkchVgVx1iTWpL/Xc7coAeLzHzv6nnKCKBdcvKpipXt0gDRlIUOmw1rcQNDFGgUlhyx9FkNP/RMQgAAAAClBn0xFESwj/wAAFZMrtQji+8fiSk3hv+fKSVyaEvaKPixkPO8iMSbuOQAAAC8Bn21qR/8AACG5wVHZTN8HlCxG4s42AED10Y7r5xEDTrxRNYpVd8rymfaHI1ryYQAAAD1Bm3JJqEFsmUwIZ//+nhAAAEFD1Ti4wzObzRT1ZCxK2WuifIiVzBUnK1oPZAq96bS5EGAG03C/qFJ5yFCHAAAANEGfkEUVLCP/AAAVkp7eNxtHC/l0iDe/8AQ7d33U7WdBbpPDeCRRdnyvLR0jC7l//ki5rXAAAAAmAZ+vdEf/AAAhwLjfwV6R2pnOmTkd2kjniEEpEDOqW6xFKBmu7kgAAAArAZ+xakf/AAAhrjEv0XlDs822QSHvPABwSvIra4CLWcLnW3e+doq6BBdO2QAAAFJBm7ZJqEFsmUwIZ//+nhAAAEG6bz28sUJY2SC6t11oewyduq6Wlb3Vckc/TqoP0LZ0WQACIigfjNxlqBAhwW6F/cDKR8/AZCfp3ics8CCZRcpgAAAAL0Gf1EUVLCP/AAAVlSX9TKsOQVj1Xt6N7o3+G6sCVBsUuEDbbT0afZjUVNYGwCHTAAAAKAGf83RH/wAAIawVDguyIH209OgoPC9R9KWiOaKkQAl1tZiNkdUD8mEAAAAvAZ/1akf/AAAgrjL6/RCM2OwIg/b+zwAsInADnHR+XSRKnleiemg1r/hoJyvH/ZgAAABeQZv6SahBbJlMCGf//p4QAAA/djnAQb8ft2mEUAAaDckyKuL4Q0oiHz5wPtYX12u14dCODo7YKjc4wsSmOXfivk4yB8Bb1hfk4twJoL11cmOCli6olHIO/gVhXKguYQAAAD9BnhhFFSwj/wAAFQKfCdEqn6K0BROjEZAAfzqWBLfySlQuijTFSIR9uGJTlIrLCzOVQCKA2VYQFCm1bdTNDH0AAAAlAZ43dEf/AAAgwLmhvBo6rIUdGki3+rBTQb75QRwgBM/QfVNWZgAAADIBnjlqR/8AACCuMeJ1oq+LPLPQAtWAYHeA6HuMq58zJcPOTibTZ+QQvKQyJQ+x2rTP0wAAAFxBmj5JqEFsmUwIZ//+nhAAAD9qcM2vY0AoQIBmg9aQN+TX3pSy+jFsIGMLaD8pBlX/5ADttdiAeyQmR8eFKejhzhfAFwP8qS7ljzwuSDLLHS8syqw661CXDGjHlwAAAC1BnlxFFSwj/wAAFQKfBgE0gaEUToAAupll7hQEY5CdLkqtmUjRiqmEh/B8BH0AAAAiAZ57dEf/AAAgn0772nBPb3ro3FK8dS6q4JVoh3cwdeaVYQAAACIBnn1qR/8AACCuMjaqdgxYwgtJjOha08G/ODFDOm8RVIWYAAAAbEGaYkmoQWyZTAhn//6eEAAAP15wzmnJ6cAgFtPxJsNJ+jGVCJ9hxUkGGZOIKwmrkUKGeCWb9ajNhwAPkCwlvxrdWtPTyfyM9j3s6gDfyTsn9BsgyYIWmnVPbvu4OFi+N563+Uu2VYZoRj+RsAAAACpBnoBFFSwj/wAAFQtfddP78cmkF0gGvHgzxFSEHd1SS1MlwykvGSu8s9MAAAAzAZ6/dEf/AAAgwLiE+/I8ZqIl6JN1ueJk1gAlim33tv/efo/qiITwTzd7zu7KlzezXHpgAAAAJAGeoWpH/wAAIL2WAooA+ycE7kb31/rZLqqce/zy9bDS9U55QQAAAFVBmqZJqEFsmUwIZ//+nhAAAD+8JzrOJB0jK+jNFrCuA8sbhOt00563RpZu6WSGmwf4MTddLdVNu66nkqsVd65MwFuHb4vxreGDZqIDB4W1vA39mFouAAAAK0GexEUVLCP/AAAVBSX9TKsOQ0v2pp42w5qrsCnBZrgiPmCYRUJtFdbKR6cAAAAqAZ7jdEf/AAAgwLjfwV6RZRRFZYjr8URXGAjwAC6GDqBPUMp6rUwIJg9NAAAAJwGe5WpH/wAAH7mn/7UuCnaLUZlT0VlDvcdFEksmpVQaVAikBrT1mwAAAERBmupJqEFsmUwIZ//+nhAAAD3+RIsAAug3c70FqNJe1JuojCt+8Eusl924Kmf/oWzRh+ICwBRErGcjTPYssZ9AJLmjCwAAAClBnwhFFSwj/wAAFHtfcMr1bAjHM4Mpc2O2rglKeofDl74EMLUMbEaMwAAAADABnyd0R/8AAB/Iyvfw9p3rPDTfAAtu91OxGXYQu+ryK8yrU7+QO2F9AXOrVvK65GAAAAAiAZ8pakf/AAAfxsBoo+KTjb/c61YrykxMDDv57eNW07uO6QAAAFJBmy5JqEFsmUwIZ//+nhAAAD3+dZDFABExtarKmRL24f5t6YRGw+/hi6EJf9xUwNd9zII8AC0sXtZFcrfRPqJiQ8v2SKto2FCO6wn6pIFTn0yZAAAAKEGfTEUVLCP/AAAUcp6otDzTwY+SKuqaNdSeZpD4RqFTqQRli5UxfaAAAAAmAZ9rdEf/AAAfyMpuEn16nRbZcoxGMkVdq/xQVwPe3sx8FN+/cs0AAAArAZ9takf/AAAfzjE/VRxml25QAlhKnHtiSSMCOjWGa5dV/wJaRS8J2flAGQAAAHZBm3JJqEFsmUwIZ//+nhAAAD4KcrCHgCdU2e/1VoRnC87duDv4E2GA6urKxiKF1Tb7wTjwCUi2NA074EhhenAMyw95sEU4nwrTDlNJxwVCuMPDtmOPOe9xwt48RAuALt+kpgL4Uc4KiYQMok4r3hXbEPLQ0TCZAAAAJkGfkEUVLCP/AAAUfmMoyIDI4Cngiw5nXRxBThummwcc51Jt95KQAAAAHwGfr3RH/wAAH8jKWRQrZNXZJ9nQMxbjJGL5Xs4t10gAAAAwAZ+xakf/AAAfuO2C+VTIuoDUnGDvIEw3JARJIVHkALcFIajMCRjBtJYYl5ohrEV7AAAAhkGbtkmoQWyZTAhn//6eEAAAPlwnOs4kHSNu8mADoYfcG0AklodvJ0yOvF+HpLkr2DTi/WoEf6mnBYCDgkK+O48b6sAqPI3adXgg5o27H29wMlR5r+l7N1TtSaTfTDjS9gOhDXwyqm8UHBUpx/1C+Pp/m8mkj8evfYpdHagGQuOTsqPTwzWfAAAANkGf1EUVLCP/AAAUdRfZyoRoQVtcpiGPRC3bUKspxmU4SjlwAg4Vtc50v+qrRx9Erzy3wQpbugAAADABn/N0R/8AAB+26Pagljd1YsHg/5p0+lppoASyljB68YBQUVtgFokd2Qw77nqOt3UAAAAtAZ/1akf/AAAfFsDLu3ncf/zC6J3xRIWUpKv43RIm1syHPTcU5PEDqTPX73dAAAAAa0Gb+kmoQWyZTAhn//6eEAAAPMi37v24tyRbl6kvp5AupNFq7vveMkwAdaUsAjs8Aj0iqNgbNSigLsgZiVPiBMPlvGA+frYf0gHUxgTKIFwY+t+QI0h9oe841Ha9mI0H83gkHHvY3sBFoX7dAAAAOkGeGEUVLCP/AAAT4p9NsIZn1L0AT//P58AewdXOYloMHKcAAakDWPU1pMDDixhq9R729utZAs4kcoEAAAAoAZ43dEf/AAAfBul7r6bpwon+nmEGZ50IatHmGHToc8Nmfxczuuq9owAAACwBnjlqR/8AAB8Jp/+1ETxXvC/Uq5VAYxvB1NhNrMAnzUnI1gLw0GHqJx1ggQAAAGVBmj5JqEFsmUwIZ//+nhAAADyecNdGzgKxZ4jI2Gtk8bWEEaFT5u7qoMcBSGSsAF11yBjxOagenryL//K3gv/+ydye4aFFqYzy6DO1YC0XsQ3hcCitNyBSqcy39WJWsNGbdFgzoAAAADlBnlxFFSwj/wAAE+KeqLQ809LKPU8O6hns3sZhQ9okJ5Mr0Kk2fpssogBKkAioncRH4f4WP0LV/SEAAABAAZ57dEf/AAAfGMpZFCtlKdRwvOZS4+P3rpj3m0DwbQ8CkQRIRNWC1zT9FUACcM9tVGXZmUDpT89dOin+T9FPSQAAAEABnn1qR/8AAB8Jpn9ReUOz2oR6e+1+wO/JuiqsDUgMrb2Em+npowRe0oAE4MBHVv8R+B5V7RwiYD4yUD6nWsMcAAAASUGaYkmoQWyZTAhf//6MsAAAPPyDM47QHVGoD+J1f8wn+J7KMANxDRs1DfrSSKthyVvHK02QOcSLWjsa59IsQ70664whvzwDQRMAAAA8QZ6ARRUsI/8AABPint5UhAA6A42w0AuwU7lJdI3VtXf6JSWbtzXntX/g0P7jZMgGQp9SxfllrG2tlFmhAAAAQAGev3RH/wAAHwbo8U9tKeKWX6ix17Ag0UZtrItddZp77kpcmadanuaUP3QAP3HhckFBXheGoIvXLbyk3vkSFmgAAAAqAZ6hakf/AAAfCacF4DyMs1su/B0wN9UNGyUhnMq7hAkN2Sb3wCMVUb0hAAAAbkGapkmoQWyZTAhf//6MsAAAPVwnP2vO4StcqkzssAITon2H64cFUCZ4+qi1jTBTA/bjnysaN8ydqCs+GrvpMpsBjdzVACDiXqinINTq1cU/daE7mbGF+7D+u4fd875tV/7hj70EsfIRLV3Ombs+AAAAN0GexEUVLCP/AAAT5SSh/aVTAFOHyjw9F5Jdk/HIlyiDYd4i7g7HQp4cb3tB8lQZ3cyNnA5O8oEAAAA+AZ7jdEf/AAAfCI4sTENIDm4AOkAhSK9uC6vEWwf1bkTjktkM0pY/j7fllGJ530Psu9EHay6oI8WQR480u9MAAAA1AZ7lakf/AAAeWaf1PVVZQAn3TXmCqkBp8Sqh52aMAXQPLQEmko0GACINNF3/uTWnO7yWg+UAAAB/QZrqSahBbJlMCF///oywAAA7nIMn00u6lvbjWTvcAzk+UP49CZYQbYrQIzdpZRBO2fpodhHdnafdkgV/WJ7M/UONHrHnbGm9p6gS2QvfWUtj6gBDpEUeQOLWG6hBWE2G1FAYwUHJ141LEXuCCXprHzGGnYvw2CcItiBTyCGS8QAAAE5BnwhFFSwj/wAAExzL2oI8sa+sUXACZXjZpqjzqFJQCSWjyKSrIaDJe6tDHFdhiDATUPPgRPygafebsDo3IDXkRdqAuhm3DGo1nrQtuPQAAAAyAZ8ndEf/AAAeTjTqfWWyFJvuzThOcRn77QQcjNqrvAS3/lXZshcKgjm4ylpiGvEbvSAAAAAtAZ8pakf/AAAeWaZ/Uc4htjHru7aXlsShRz/JuGPgVXs0RCdsJK0Omps2n0CpAAAAUEGbLEmoQWyZTBRML//+jLAAADunzMoFd01URoYAIfdmT6bQK0XWcLY7fmEyHxCg9Bqcg5zEXxmUmy/CA6eolC2+FpMCcd6uaPDQJuCXZkaIAAAAQwGfS2pH/wAAHlmmf1HOjTU8woPYEl5rnHIXlY2bVB7ZoUwwUxrAycgA/mL81yMzhb7cAQKYX6LjI3ccW8CGNRPs17QAAABjQZtQSeEKUmUwIX/+jLAAADv8J0U8WtazodAFaGEyEHZTS0IQZqbL8dgYpUKQ9Dtue4ViTcFp8XLjdF2T34PdqLXOdVUY+WD5iN6qZBfd9zghcb+f7MWJd4Yvkr/AW8E/01OBAAAASEGfbkU0TCP/AAATXSVB5W7N1j7cZkqO8bW+MJt3ZPtMkzzb3VN63KcEsZsO6h0rhvWBEsrUPhfaO/VAAXMkZQhjmLHv8Xi9oQAAADoBn410R/8AAB5omOT6sAkKgtI26RACyYOX9gUCpGvamvwo8Xb5VYfyafvF5BH6WAkxjgILBCrMlezBAAAAQAGfj2pH/wAAHlx66hVTsOnKNFPK2pcl5k5o4sHSRe3zuQhm/MtvB4o5KWZQAHvxfbsnYl9fJzMrhSO+EYE3XswAAABmQZuSSahBaJlMFPC//oywAAA6SxNfWcALD6lCaNcKCoKXjLgA0vZ90M0mAxjpfNNRpLk/UFVgLCoW2cHnKBJr057sads6LZx9CwnN0ika2dJfwQqGWjaFY+AR1FN5ccnD4orH+eJsAAAASAGfsWpH/wAAHamn9lZ0vgluHexxxKqyr0AY1Y8L5VU26xrWceLx0cu3KgJdKm6AC0PwByu1MuCyo+mWuSb7fUlEeu3A7NM75wAAAEZBm7RJ4QpSZTBSwz/+nhAAADneQ8ZvQQLIL73zSiOQ1CT/+wh+8mfJXhST+g+fngjfL+fd1asd9j5J1Lv/tyklsJ6IlmjWAAAAPwGf02pH/wAAHbZjbEMV9eSfCMNCNRyC/2MfguHX8Isw68+mQzISSMdXHraaAAe1ofdG35C82U9oPhn00xQgzQAAAENBm9hJ4Q6JlMCGf/6eEAAAOd6LLxtvGvcqQpPMwikZRrGkinz+4qUnZBbosYsPf/Dg5wvvWik904L60/7IJNTJKGyxAAAAPkGf9kUVPCP/AAAS1b477OIRQDlz8NPs9MChlnZxYdgF4fyx0tNSd4gUeo7yVXcRCM2JkBGVUdBQllCo/jXQAAAATAGeFXRH/wAAHbhJ5qSAFYudWyodRFHAjwM7C0Lj0FusKnjq5uojxC7YfbO4W5J4R3jHS9R+tRWzky5DV2XxHltxxiVjkivcgWH2G0cAAABUAZ4Xakf/AAAdqaZ/UQKgTmHSO6I2AAtv3b6xIF1XdS0ZgXWdUI6aACFb7WlGfEBuOq0gAXcOcHlPZXgtGTFl1QFqi5d4QnjBtulGomd24ICESu/xAAAAb0GaHEmoQWiZTAhf//6MsAAAOpwnPdKdFgAOPbUTPkc0dBbbukQI0iBgHkekYbuxQzIsP7VF3tyPS+qC7wrkT+DPuQ9DOop+Q8j+T82axb0XS0cfYmYkb2OcUbC9aP1IPckyNBZ2VxfgpQsJpVSnIAAAADpBnjpFESwj/wAAEtf+ZhpwBaQAKB0VdbeZAupNQ+uPUQXG1tAMNbWOz+NXyeWJ6nsb6XRkjuqDlr7hAAAANQGeWXRH/wAAHbgs/y8T9FPCJ+Q80HnP9FCQ+vQIiD524IvZbnaspI+kqfA5/iqaI1UGyFHAAAAAQAGeW2pH/wAAHQZjjF51LktcqgET7BMllVfAEV1gTYJwsPvHoUWU93kr28utoeEoXIB3mZoAE4msumbto4xNL/EAAABkQZpfSahBbJlMCGf//p4QAAA4fn/xm9DDCjjF0AGwtNsc0l/wl9jZHrE0iVv4lqTZtIhqutVMetbovCxvowjEOuKa/QBYcRgQ8p7oaQ92gwTSo2e6IwgIoMu2AHCdAwTmN4uDwQAAAFNBnn1FFSwj/wAAEmI5t7AQxUADt+fVZrvxt1YQnXei0UiTq6XhW5+2Bq2VSCm1a4uw2e/LK50Up3J9L/AYEV/UGqeEkIdjB1u7pLEz5KeKz5riDgAAAD8Bnp5qR/8AAB0GYybmQ67Q1Kx4pcHG9Esu2YNh6SOmCKABxIxPCV6matin6t5/Gfaa2bVDOgdaF+1I3GdKqJgAAABiQZqDSahBbJlMCGf//p4QAAA43Cc/uKj7Cxw1IkIz0hyVxzIADn4r0ZhbZS8nUMLlfratnlqA2sU5HdA8Ci3DlkRbcgkhEpLqKaEx5mKTRzhej9u5O9RCcCxAlZ+Ejj6LQs8AAABOQZ6hRRUsI/8AABJiPM14j7RoCyDvda+9JOTMoyPiawB9/ubmwje5DueEXJwDkHxSYJOXjK4aWUItxidfYiMRJUPxFvECt8DHggia3ghUAAAASAGewHRH/wAAHQgs/y8T1EoZx8uPP9LORbVq9xGzsDzyfFFtZfxPRyrJmI73QATH44Ac4BPy163lZrBVTN/pMUken7JZ98oAgQAAAEIBnsJqR/8AABz47Ta9GtUn6Qul36fiuisIcFHmCTZxxZVBIUIgmaTK0JYOmGpgA1Gd/xI9X3tqqZYb0F9B5oqTCFQAAABxQZrHSahBbJlMCGf//p4QAAA3K9DnqAIrG+1rXF+JCfpl3gll1MDahwH2nzSjD1wmDIzvGykaUOxovX1rChnOn+TV67be4Id01W+471Ym5fya9/2JmV/K/SNP/AjOX+FJq264vP4AMa9GEx+cmzhN2MkAAABCQZ7lRRUsI/8AABHdNpWQ7VVT7otZ5iASD+Uu/ZP/F2mrepbDr6oPFFiRQkGjK70G+Ie+ZJu+CAFvg2EI1EDWlcgDAAAANwGfBHRH/wAAHFgtVKbfHPJkx77t9pZPV4lceUbu1+jJRN0yqsSwyEPkJL7FjKAT58ZqcwxLwcEAAAAxAZ8Gakf/AAAb9OK0E3VcgIrhcV6zGYGRsS1RQ7/K2KN0WauaKuMLO9XlC10p/nX4OQAAAFxBmwtJqEFsmUwIZ//+nhAAADcr2l+6yMGNVs7gw3HwJJkAWjh9CTIsoOFxOzdE6YhH8xgAjhhTw3IngTECt3g+A4JjN/NqlzvO01DRftU6AnI0xPem9YugujcoKwAAADdBnylFFSwj/wAAEdXgy/8fC+8+7JbVeg05Ldd00+y8yOQ71Jrtu4sFSYghwjOvlkBo7VJYjFgzAAAAPgGfSHRH/wAAHFgsoqStqpW8JukMk8//Ql9k364IRaAIX3Pq1FQpPyYBe55zX2My4AHo2UnO/W3uBte6Wnw/AAAANAGfSmpH/wAAHEjtNr0qNPqBKGq9eMVAAPiEk3+enVwquDdj+kIVC+rS+lBTv2nU0gptsCwAAAB3QZtPSahBbJlMCGf//p4QAAA3fCc61Dd6n5FWgMFSCMfmL2ew79eWdRU1gj3s5D18fhBuw7GqsyMfjNvVWWGFi9nkM9U4snBbpzGVgnxVEJ9WyrpD1VvZ29PyGvpRIw8Xiobf5+Vzh2FwiDn3Yd6RFFhqASfxbkAAAAAzQZ9tRRUsI/8AABHX8RIQSDZ67AE5Kjeu0Y9TZi/7ZYm4ahXZS30l7Cd1MsXzonzpGS+lAAAAQgGfjHRH/wAAHEiNjcYBS8bvUpe8VKWQZGSSOPfKJzD2mGQLwLkddAA2GDnSgpzuzMoTpCqzUTzkDd1p3y7xFmVgsQAAADcBn45qR/8AABucX9ofYBDnrlE8Cyz1+SvdhIIzFcS0h46ac/YXlVzUWUdM0SJwt75BHEtwEV4fAAAAg0Gbk0moQWyZTAhn//6eEAAANfPqHjc9BABIA+ABw3oxbTWEY3Ri3EL5cZ7EtkPz2WxH8pYzYL+WW4nuevgp13P+nVp+4z6Ag98PdrHAs51bp5F0UMGABg/ixIDLhIkmbtIqpspkeKrDbozPFD2pdCQ4YJM1iLs7rK0z6i6zO4upPEEIAAAAPEGfsUUVLCP/AAARXTaUI9mRZx+W7xiVZuVEfge76A3PfDbftpDtu0r96BC55o9D3UkAH5nDdWTEIqEPSAAAAEIBn9B0R/8AABupbbykpq43ap7ICmxizdOFatiiGOoYjs52AD78GeDLPZg9dcUbqbfZLieGlJH08w+JeSvZIbJ8pnEAAAA1AZ/Sakf/AAAbp9p6sSdejr8cIlTpwWzEz/XPvUVDtds7omnwYF7cgvY9ozj3AgSLHPOmavkAAACCQZvXSahBbJlMCF///oywAAA2nrZ+1iMGAHQLPtRFN3b5fLj9kCgkfxL64e401uqfW8CwUiDM1mDYB1I+vvRgGXGRWXLXbRJRJxVTEvgM+F9/5l6Dm2kucL/MxtzYTuKWDQtgfoOsgQt9nBYwfHLWavFgIXsXw0QiWrpYSI0j0oA+uAAAADxBn/VFFSwj/wAAEVgFn1uIoB5mImGA1805/iM6FvMYz8XzpFfpcdf2uqEbxXivSSTB804BLNafbvEQZi8AAABNAZ4UdEf/AAAbm/6xRhEpy8wEUTB/y/h9xcRXJZO4x+vmSGz5Tl6jpe6ABsNl1uJxFJ8QGkoORnzWymp9Oq/qa6oBxodwGq78u+8sKi4AAABMAZ4Wakf/AAAbB9p/J43sIfBdFZs9V8rAUrlxrGCr0GYmbOmY2umzhUa7t+FWKj3oGGm9eHAEYgCRxCKOXtyVjl7/lq729/H/Gs3/qwAAAGBBmhtJqEFsmUwIX//+jLAAADVcJz3VTlXptA97va+w9GD0CPg2/1m+3w1KEVTkfeqTUkHXYfGSZy56AGuig0JmtT4QPQdEh5Tpn8yoUo753kPUZcaBSDa0BBU0kyrurxEAAABEQZ45RRUsI/8AABDiPtvfWvea9kBWPKQDFb0Z4Nd9/yagAIyDTJ8g4QSg2lupJiyERcMP0Oq4ptwSv8QrAm8at1Ixn8QAAABSAZ5YdEf/AAAbCW28pHIB1NO8NcHE0T/bWjTXnbGl7SmRUVzyPIFmtVUt/+ACcM9tVGXZmUC4IHRjjuwVPBqTMlvVJTDxYZSYuUS1P0fGOlqcQQAAAEABnlpqR/8AABsH3zK+AD9hZEu8UFmuYn/rFOSHaUin/K8nXAQJOynSUBVDazwRN8PMNID+tKo80jtOFP+3O+YGAAAAb0GaX0moQWyZTAhf//6MsAAAM9SDxz4oJ6PaKw9f4YNnKKMzsIQIS6gd5sB7fKEk74QEmJJGH+wZgQe/cW4cIDIl9/xd6z3d3nBFC4mFxHFRri3QM5+e5e5UZxISKrGyfP5FFWmpeF+hEIkv6seWgQAAAFBBnn1FFSwj/wAAEByiy/IFjiIAJ7Ftm06WX6UZ9Psje7P8VlNqnVQm5q4U0id3aiI+YsbxTIKiWYacHa5+ApmGaURd+2ycqYXPISUcPwxpgQAAAEIBnpx0R/8AABpjZS+VfvrTWi2dzs2KffAP0m0ZrXUQ7vQ0LtCD6kliDtGpET3cqABtFKJ5VlQd6HRIoUVVxdU9kOAAAAA0AZ6eakf/AAAaXF9j9I27POnU6rk7w3AyJbEkWWPPLLgBZr+ngdghM//WPPaqMMa0XmslIAAAAHVBmoNJqEFsmUwIV//+OEAAAMnv/OLieH1UDNl+/5N6e5gT/MBKQVqi95OFVBKqik2YIQbLff/VjLs9EAQzo7vI6LpSSt3eBggDHkXES1pQtOz1NDiEwfDqAsNwDdzb3Ox+I210AmE1cVqdzd+owBhmCxkDOaEAAABJQZ6hRRUsI/8AABBYBZ/l2js7QgCnywq41WEdIUwSRBwhisz/MMsLUVek/amaZyrq2o77/8LfEY3X64sDUEgcBvn3sUo1QxGGgAAAAD4BnsB0R/8AABpjaLmQGFM27N8OOXEER2x19mjN6P3xQZnFvvv22X99uLzSZAA1Gc/f0T+2t2XSrdjIwCLJHwAAAEABnsJqR/8AABnOmkuISGBjmFeumlA/nlPRh0olNXikCU5u+YVVuWEk5xPuHOv9HM/to4pAA+6p/Uy7mbEvxcx4AAAAUkGaxUmoQWyZTBRMK//+OEAAAMOd/2foJm5QRq0fWVzuBPgN/9pa3/iK9v/vpi50LKLccShL3dPGFiAECFwUCzNv67PUsGSqjAMO7KUG9dbUQVkAAAA9AZ7kakf/AAAZsKhYmUhqCzHdtQMF+bdjS2TNfgvf/V6Nv7Ktd254orIieNZz0rcsWhhxIQWmfVt91NzZcQAAAFtBmudJ4QpSZTBSwj/94QAAAwL/v+vgJt863Y9qOS+6Ao/MxmelgHAGENjDYrSApBgPb3rXptgzeOkgATI9GPTYVV62Xt2FUGRB52mX71xwJ8uR64BXKQ9USjVxAAAALgGfBmpH/wAAGcd7NLN1axEJaPxz9xHBN/2Dd4cQgQh5qh+ZKtUW5AiL1Z7G5I8AAABLQZsISeEOiZTAj//8hAAAC1Iqq23rXjAtaML5I1SNVX+QaA6cQooMA3sAOHgQhGVBABEG5DHy+cQ61DgOdHqxrzzXKxibw+ml32+WAAAMV21vb3YAAABsbXZoZAAAAAAAAAAAAAAAAAAAA+gAAA+0AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAuBdHJhawAAAFx0a2hkAAAAAwAAAAAAAAAAAAAAAQAAAAAAAA+0AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAJYAAABkAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAAPtAAAAgAAAQAAAAAK+W1kaWEAAAAgbWRoZAAAAAAAAAAAAAAAAAAAMgAAAMkAVcQAAAAAAC1oZGxyAAAAAAAAAAB2aWRlAAAAAAAAAAAAAAAAVmlkZW9IYW5kbGVyAAAACqRtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAApkc3RibAAAAJhzdHNkAAAAAAAAAAEAAACIYXZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAJYAZAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAADJhdmNDAWQAH//hABlnZAAfrNlAmDPl4QAAAwABAAADAGQPGDGWAQAGaOvjyyLAAAAAGHN0dHMAAAAAAAAAAQAAAMkAAAEAAAAAFHN0c3MAAAAAAAAAAQAAAAEAAAYwY3R0cwAAAAAAAADEAAAAAQAAAgAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAIAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAIAAAAAAQAABAAAAAACAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAEAAAAAAIAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABAAAAAACAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAAAgAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAMkAAAABAAADOHN0c3oAAAAAAAAAAAAAAMkAAARZAAAAsAAAAFoAAAA3AAAAOAAAAKUAAABEAAAALQAAACcAAACeAAAAQwAAAC0AAAAoAAAAQgAAAEAAAAA0AAAAMAAAAIYAAABKAAAAIwAAADgAAABwAAAAPQAAAEIAAABbAAAAPwAAACYAAAA2AAAASAAAAEkAAAAuAAAAOgAAAGYAAABEAAAANQAAAFMAAABQAAAAMAAAAFEAAAA4AAAAeAAAAEwAAABbAAAAWwAAAF0AAABCAAAAWwAAAEUAAABNAAAASwAAAD4AAABYAAAATQAAAD0AAABPAAAAWAAAAE0AAABHAAAAPwAAAGoAAABBAAAAOAAAAEUAAABnAAAALAAAACYAAAAmAAAAUwAAAEUAAAA9AAAAZwAAAD8AAABaAAAAPgAAADcAAAAwAAAAdQAAAC0AAAAzAAAAQQAAADgAAAAqAAAALwAAAFYAAAAzAAAALAAAADMAAABiAAAAQwAAACkAAAA2AAAAYAAAADEAAAAmAAAAJgAAAHAAAAAuAAAANwAAACgAAABZAAAALwAAAC4AAAArAAAASAAAAC0AAAA0AAAAJgAAAFYAAAAsAAAAKgAAAC8AAAB6AAAAKgAAACMAAAA0AAAAigAAADoAAAA0AAAAMQAAAG8AAAA+AAAALAAAADAAAABpAAAAPQAAAEQAAABEAAAATQAAAEAAAABEAAAALgAAAHIAAAA7AAAAQgAAADkAAACDAAAAUgAAADYAAAAxAAAAVAAAAEcAAABnAAAATAAAAD4AAABEAAAAagAAAEwAAABKAAAAQwAAAEcAAABCAAAAUAAAAFgAAABzAAAAPgAAADkAAABEAAAAaAAAAFcAAABDAAAAZgAAAFIAAABMAAAARgAAAHUAAABGAAAAOwAAADUAAABgAAAAOwAAAEIAAAA4AAAAewAAADcAAABGAAAAOwAAAIcAAABAAAAARgAAADkAAACGAAAAQAAAAFEAAABQAAAAZAAAAEgAAABWAAAARAAAAHMAAABUAAAARgAAADgAAAB5AAAATQAAAEIAAABEAAAAVgAAAEEAAABfAAAAMgAAAE8AAAAUc3RjbwAAAAAAAAABAAAAMAAAAGJ1ZHRhAAAAWm1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALWlsc3QAAAAlqXRvbwAAAB1kYXRhAAAAAQAAAABMYXZmNTcuODMuMTAw\" type=\"video/mp4\" />\n",
-              "              </video>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {}
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OpqXiZUsznkY"
-      },
-      "source": [
-        "That's it! We have successfully solved the Cartpole problem!"
-      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
-  ]
+   ],
+   "source": [
+    "display = Display(visible=0, size=(1400, 900))\n",
+    "display.start()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "l8qDfZi_R2xW"
+   },
+   "source": [
+    "Below we have a utility function to enable video recording of the gym environment. To enable video, we have to wrap our environment in this function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "V2bZH987tHtT"
+   },
+   "outputs": [],
+   "source": [
+    "def wrap_env(env):\n",
+    "  env = Monitor(env, './video', force=True)\n",
+    "  return env\n",
+    "\n",
+    "env = wrap_env(env)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_iOU0i6sUg9D"
+   },
+   "source": [
+    "### Set the seed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "rQljT2b2k1Qy",
+    "outputId": "dfaa0eeb-e1c7-46c5-a266-a06b508229aa"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<torch._C.Generator at 0x7f76fa684730>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "env.seed(seed_val)\n",
+    "torch.manual_seed(seed_val)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ax8ToOAviGGS"
+   },
+   "source": [
+    "## Model\n",
+    "\n",
+    "We are going to utilize the reinforce algorithm in which our agent will use episode samples from starting state to goal state directly from the environment. Our model has two linear layers with 4 in features and 2 out features for 4 state variables and 2 actions respectively. We also define an action buffer as `saved_log_probs` and a rewards one. We also have an intermediate ReLU layer through which the outputs of the 1st layer are passed to receive the score for each action taken. Finally, we return a list of probabilities for each of these actions.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "XVS15FELytIj"
+   },
+   "outputs": [],
+   "source": [
+    "class Policy(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super(Policy, self).__init__()\n",
+    "        self.affine1 = nn.Linear(4, 128)\n",
+    "        self.affine2 = nn.Linear(128, 2)\n",
+    "\n",
+    "        self.saved_log_probs = []\n",
+    "        self.rewards = []\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        x = F.relu(self.affine1(x))\n",
+    "        action_scores = self.affine2(x)\n",
+    "        return F.softmax(action_scores, dim=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dAKv4jUmrnbj"
+   },
+   "source": [
+    "And then we initialize our model, optimizer, epsilon and timesteps.\n",
+    "> TimeStep is the object which contains information about a state like current observation, type of the step, reward, and discount. Given that some action is performed on some state, it gives the new state, type of the new step (or state), discount, and reward achieved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "J1Hb2LQveKR6"
+   },
+   "outputs": [],
+   "source": [
+    "model = Policy()\n",
+    "optimizer = optim.Adam(model.parameters(), lr=1e-2)\n",
+    "eps = np.finfo(np.float32).eps.item()\n",
+    "timesteps = list(range(10000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "elcEG2gojTsI"
+   },
+   "source": [
+    "## Create Trainer\n",
+    "\n",
+    "Ignite's [`Engine`](https://pytorch.org/ignite/concepts.html#engine) allows users to define a `process_function` to run one episode. We select an action from the policy, then take the action through `step()` and finally increment our reward. If the problem is solved, we terminate training and save the `timestep`.\n",
+    "\n",
+    "> An episode is an instance of a game (or life of a game). If the game ends or life decreases, the episode ends. Step, on the other hand, is the time or some discrete value which increases monotonically in an episode. With each change in the state of the game, the value of step increases until the game ends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Q4ncIcYcznkQ"
+   },
+   "outputs": [],
+   "source": [
+    "def run_single_timestep(engine, timestep):\n",
+    "    observation = engine.state.observation\n",
+    "    action = select_action(model, observation)\n",
+    "    engine.state.observation, reward, done, _ = env.step(action)\n",
+    "    if render:\n",
+    "        env.render()\n",
+    "\n",
+    "    model.rewards.append(reward)\n",
+    "\n",
+    "    if done:\n",
+    "        engine.terminate_epoch()\n",
+    "        engine.state.timestep = timestep\n",
+    "\n",
+    "trainer = Engine(run_single_timestep)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "MfHpIGCEpk0Q"
+   },
+   "source": [
+    "Next we need to select an action to take. After we get a list of probabilities, we create a categorical distribution over them and sample an action from that. This is then saved to the action buffer and the action to take is returned (left or right)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "B2xxebxhd9J8"
+   },
+   "outputs": [],
+   "source": [
+    "def select_action(model, observation):\n",
+    "    state = torch.from_numpy(observation).float().unsqueeze(0)\n",
+    "    probs = model(state)\n",
+    "    m = Categorical(probs)\n",
+    "    action = m.sample()\n",
+    "    model.saved_log_probs.append(m.log_prob(action))\n",
+    "    return action.item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WV6he1cvuFcw"
+   },
+   "source": [
+    "We initialize a list to save policy loss and true returns of the rewards returned from the environment. Then we calculate the policy losses from the advantage (`-log_prob * reward`). Finally, we reset the gradients, perform backprop on the policy loss and reset the rewards and actions buffer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "y8pctWff5Ev6"
+   },
+   "outputs": [],
+   "source": [
+    "def finish_episode(model, optimizer, gamma, eps):\n",
+    "    R = 0\n",
+    "    policy_loss = []\n",
+    "    rewards = []\n",
+    "    for r in model.rewards[::-1]:\n",
+    "        R = r + gamma * R\n",
+    "        rewards.insert(0, R)\n",
+    "\n",
+    "    rewards = torch.tensor(rewards)\n",
+    "    rewards = (rewards - rewards.mean()) / (rewards.std() + eps)\n",
+    "    \n",
+    "    for log_prob, reward in zip(model.saved_log_probs, rewards):\n",
+    "        policy_loss.append(-log_prob * reward)\n",
+    "\n",
+    "    optimizer.zero_grad()\n",
+    "    policy_loss = torch.cat(policy_loss).sum()\n",
+    "    policy_loss.backward()\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    del model.rewards[:]\n",
+    "    del model.saved_log_probs[:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "UwuJs3n4tEe9"
+   },
+   "source": [
+    "## Attach handlers to run on specific events"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pPiGVM8FwRSC"
+   },
+   "source": [
+    "We rename the start and end epoch events for easy understanding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2K19lOcPeFF4"
+   },
+   "outputs": [],
+   "source": [
+    "EPISODE_STARTED = Events.EPOCH_STARTED\n",
+    "EPISODE_COMPLETED = Events.EPOCH_COMPLETED"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "igNnguT3wWqu"
+   },
+   "source": [
+    "Before training begins, we initialize the reward in `trainer`'s state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "QNoGCUe9j6EF"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(Events.STARTED)\n",
+    "def initialize(engine):\n",
+    "    engine.state.running_reward = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yB-tEz9awzoj"
+   },
+   "source": [
+    "When an episode begins, we have to reset the environment's state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nN3P6Zq6wVo_"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(EPISODE_STARTED)\n",
+    "def reset_environment_state(engine):\n",
+    "    engine.state.observation = env.reset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NvTZVIAzxOCh"
+   },
+   "source": [
+    "When an episode finishes, we update the running reward and perform backpropogation by calling `finish_episode()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wVEZBDeAUAwy"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(EPISODE_COMPLETED)\n",
+    "def update_model(engine):\n",
+    "    t = engine.state.timestep\n",
+    "    engine.state.running_reward = engine.state.running_reward * 0.99 + t * 0.01\n",
+    "    finish_episode(model, optimizer, gamma, eps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pJV6beL4xf10"
+   },
+   "source": [
+    "After that, every 100 (`log_interval`) episodes, we log the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "r1EvA2qJUFb6"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(EPISODE_COMPLETED(every=log_interval))\n",
+    "def log_episode(engine):\n",
+    "    i_episode = engine.state.epoch\n",
+    "    print(\n",
+    "        f\"Episode {i_episode}\\tLast length: {engine.state.timestep:5d}\"\n",
+    "        f\"\\tAverage length: {engine.state.running_reward:.2f}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Kfa3fHTqxl2A"
+   },
+   "source": [
+    "And finally, we check if our running reward has crossed the threshold so that we can stop training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rzdhbUxSUHmk"
+   },
+   "outputs": [],
+   "source": [
+    "@trainer.on(EPISODE_COMPLETED)\n",
+    "def should_finish_training(engine):\n",
+    "    running_reward = engine.state.running_reward\n",
+    "    if running_reward > env.spec.reward_threshold:\n",
+    "        print(\n",
+    "            f\"Solved! Running reward is now {running_reward} and \"\n",
+    "            f\"the last episode runs to {engine.state.timestep} time steps!\"\n",
+    "        )\n",
+    "        engine.should_terminate = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kpU3b8ymtPCD"
+   },
+   "source": [
+    "## Run Trainer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "jjNcMaLkks8M",
+    "outputId": "492f1c2d-a735-45b3-cee2-f599b5717f05"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Episode 100\tLast length:    66\tAverage length: 37.90\n",
+      "Episode 200\tLast length:    21\tAverage length: 115.82\n",
+      "Episode 300\tLast length:   199\tAverage length: 133.13\n",
+      "Episode 400\tLast length:    98\tAverage length: 134.97\n",
+      "Episode 500\tLast length:    77\tAverage length: 77.39\n",
+      "Episode 600\tLast length:   199\tAverage length: 132.99\n",
+      "Episode 700\tLast length:   122\tAverage length: 137.40\n",
+      "Episode 800\tLast length:    39\tAverage length: 159.51\n",
+      "Episode 900\tLast length:    86\tAverage length: 113.31\n",
+      "Episode 1000\tLast length:    76\tAverage length: 114.67\n",
+      "Episode 1100\tLast length:    96\tAverage length: 98.65\n",
+      "Episode 1200\tLast length:    90\tAverage length: 84.50\n",
+      "Episode 1300\tLast length:   102\tAverage length: 89.10\n",
+      "Episode 1400\tLast length:    64\tAverage length: 86.45\n",
+      "Episode 1500\tLast length:    60\tAverage length: 76.35\n",
+      "Episode 1600\tLast length:    75\tAverage length: 71.38\n",
+      "Episode 1700\tLast length:   176\tAverage length: 117.25\n",
+      "Episode 1800\tLast length:   139\tAverage length: 140.96\n",
+      "Episode 1900\tLast length:    63\tAverage length: 141.79\n",
+      "Episode 2000\tLast length:    66\tAverage length: 94.01\n",
+      "Episode 2100\tLast length:   199\tAverage length: 115.46\n",
+      "Episode 2200\tLast length:   113\tAverage length: 137.11\n",
+      "Episode 2300\tLast length:   174\tAverage length: 135.36\n",
+      "Episode 2400\tLast length:    80\tAverage length: 116.46\n",
+      "Episode 2500\tLast length:    96\tAverage length: 101.47\n",
+      "Episode 2600\tLast length:   199\tAverage length: 141.13\n",
+      "Episode 2700\tLast length:    13\tAverage length: 134.91\n",
+      "Episode 2800\tLast length:    90\tAverage length: 71.22\n",
+      "Episode 2900\tLast length:    61\tAverage length: 70.14\n",
+      "Episode 3000\tLast length:   199\tAverage length: 129.67\n",
+      "Episode 3100\tLast length:   199\tAverage length: 173.62\n",
+      "Episode 3200\tLast length:   199\tAverage length: 189.30\n",
+      "Solved! Running reward is now 195.03268327777783 and the last episode runs to 199 time steps!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "State:\n",
+       "\titeration: 396569\n",
+       "\tepoch: 3289\n",
+       "\tepoch_length: 10000\n",
+       "\tmax_epochs: 1000000\n",
+       "\toutput: <class 'NoneType'>\n",
+       "\tbatch: 199\n",
+       "\tmetrics: <class 'dict'>\n",
+       "\tdataloader: <class 'list'>\n",
+       "\tseed: <class 'NoneType'>\n",
+       "\ttimes: <class 'dict'>\n",
+       "\trunning_reward: 195.03268327777783\n",
+       "\tobservation: <class 'numpy.ndarray'>\n",
+       "\ttimestep: 199"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.run(timesteps, max_epochs=max_episodes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "lVSKBkaMSO2g"
+   },
+   "outputs": [],
+   "source": [
+    "env.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Z8_G4PK8SRvX"
+   },
+   "source": [
+    "### On Colab\n",
+    "\n",
+    "Finally, we can view our saved video."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 421
+    },
+    "id": "wRkNUrpQt6P6",
+    "outputId": "a2b1163c-5e9c-49d4-ce2e-d62424cdd0bb"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<video alt=\"test\" autoplay \n",
+       "                loop controls style=\"height: 400px;\">\n",
+       "                <source src=\"data:video/mp4;base64,AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAPMVtZGF0AAACrgYF//+q3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE1MiByMjg1NCBlOWE1OTAzIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAxNyAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTMgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTI1IHNjZW5lY3V0PTQwIGludHJhX3JlZnJlc2g9MCByY19sb29rYWhlYWQ9NDAgcmM9Y3JmIG1idHJlZT0xIGNyZj0yMy4wIHFjb21wPTAuNjAgcXBtaW49MCBxcG1heD02OSBxcHN0ZXA9NCBpcF9yYXRpbz0xLjQwIGFxPTE6MS4wMACAAAABo2WIhAAz//727L4FNf2f0JcRLMXaSnA+KqSAgHc0wAAAAwAAAwAAFgn0I7DkqgN3QAAAHGAFBCwCPCVC2EhH2OkN/weGVAAoD+Tf/UBEHTHT5d/yQiZHO4sg6+zQfs3HI2Y6XZYIRxBm5Rlw5hOCDQtMmgo2zuuFRyAkCAT+9j690O9LdX0vkvSqb33AZdOYYH7qaRR/tss5WLh8ulT532CFFEYvMzRgs0s8puGOPMhBR0ZjRCW8Z0rqEtwcL9cej4Tk0hBdUxtF6hnpsebLADA8EaUwpllZJh1QzIU7mYScNFckSg8ukbIRgWC1k53wt0SdRltJf2UgmeZjrPUL+px4bsCwAANsDZb3yTd4pfYTs10+T+Bo5uRJ/KzPNL/Dl8z0NKih4yPyuG6fePzY78gELZMKQ27ehFW31ciOsjpztaP2rVHecHBjejCGd0wzUpD/u6OqxJqdL87mtINCCr8neNMoDC9WvVXKyTBKAFCrxEQfLcU8HTRE3Ck5zf2gVRQHUh/T7+0L+3yetgpnZIGCACZrLQx6+QD2QAAAAwAAAwFjAAAArEGaJGxDP/6eEAAARVIuQCa1e8Eic9WotG35y8Q22j4UouROtaSMnaJLdLavH2fycnWQPwrafbUfl48e41mxkGK3Qt9e8wwm35F6tDBYIiI/koi0C8FMYJ3g7ukfZJYhve/Kb766Dv34568eUzLhIrKYYmLUg4T6aE+s4Jjtd7byju4MjPErcjhiX9+CF436E01SsTSpDYACP0RX9n/UOI6Vkhw7CQurLEoh7bAAAABWQZ5CeIR/AAAWtVlaQAKTPCg0DVgYqXZ6OIpzjPnX2+y1JZ4MgCJlIme0nlmZTkDBfp3Ct7I5ZUXzGRX4hWo6EVGpt2NvYHRchgAAAwFxQA94rFGuhvUAAAAzAZ5hdEf/AAAjrD5s3sFKk+VnV4vXc7FzsfQ5Lnj8WFT8AAADAAADAAwSiXjxUBVUr4eAAAAANAGeY2pH/wAADYKPU6xylyxViQ+s11+cJeAD+W5v72eOFilaROEiKNBlfKAAAEfhWNYQEjEAAAChQZpoSahBaJlMCGf//p4QAABFaPF1IfbdaPFByIflDUWEq1zqY70u+RQhPS4fY3dh3MIR1IGmhhqoCOE4XbCWcqgilvFr0SvIZP+sJEhPzcV8p8ny+s3etVL3MlrbXWl/x27jypNHnIwBFEh+m5q0CGn3fsSDtN/dR4voXp7WHcbGDxyTJ7atLcKIbna2TarfFZMps87XtF5JM7kZdKZ6OxEAAABAQZ6GRREsI/8AABa1WLR4pbUi6N8osAHAXCQghsP4oJQnAQgtiyImWnIg7CqjmJj9Bx+rurfZ9OoF2cKedW8JOQAAACkBnqV0R/8AACPDO/XhaOun9ZGzdLnuaJyOWHHYOJ+ApwfC6PNlg/4DUwAAACMBnqdqR/8AAA2CMPxFtfwu6fCj0PCnH892M3Ww0RAFDCAu4AAAAJpBmqxJqEFsmUwIX//+jLAAABqh8jIkAZs/FJj8RPb9jF68sePFRWvgjrAgrgK4WzA9bJta/jdj4s2BJ62oA0e6/oZVHQ9yNBMN/R869//M0EF+GsnMUdYapNj/1e50skXttNN4BTT8fcfmRgRQcLDpWG8tbTGxebdyWRIoQGO2g+r1EpoS6bQXTTnWN9VvSAaf4AwSbN1A4EFAAAAAP0GeykUVLCP/AAAIcIWMZl6CnOqysvZock1EQY1v5LuFPp4FMALUilvLiPr853Ne64RhgUJFrKX868XkqbGc+QAAACkBnul0R/8AAA1/RQ0pJAKSzGxaeBBblT2kMyYHDj7J6J/anq/5HdAi4AAAACQBnutqR/8AAA2FkDFmbJNfw8hbwYb4bxJjMHbPjMdnUlKYyoAAAAA+QZrwSahBbJlMCF///oywAAAaD+WNCcfaei2OHtsxniP2CcBX9ceVhjq1yqBlJDPK88i4uVY0ktc3zgW5jAkAAAA8QZ8ORRUsI/8AAAMDOWQNB5ognlJkCHa8mQEAlTEHhjpDgFC30Masci/YPgAkn6qGM/pdYfhlXCbOU/thAAAAMAGfLXRH/wAABPpwJbdm0rJGu5QkGeW5dLkgAH7dBYFs/8LpfnDU2e1X7uVGCxChMQAAACwBny9qR/8AAAUeWLkQP8llceZYccYBr6XAqNABMwuf/8T0Cw+q3TpuUaMHgAAAAIJBmzRJqEFsmUwIX//+jLAAAEYkG7G0BnwB65nwYZqk0zxZzEDIcop2YEhhQQRExJdgZm1WbgXGu1m2fxxSQ0h618RJxg3AX7zBiMpywLofU6KaqAzone74CtjdxpGTDvut9GncjWouu16xTy6LbIZajQBW1pWJ5j2kgvLTNP+rEs+YAAAARkGfUkUVLCP/AAAWp0JTlAAcba7OehKVjYO5ncvDZ2sVDfZfmVtbLikcLsMhr3foT7dulVc6e785F2AfvPVz+WzOkHKJ/+kAAAAfAZ9xdEf/AAAjq/houCzvaW5zUHF9NidozPU0VcsKmAAAADQBn3NqR/8AACOxzA1eLPEjwmjm4t/aW7ZnPM5nCp/K8p++AEr6D9z7oeTE/X/sHE7QLfIwAAAAbEGbdkmoQWyZTBRML//+jLAAABqtZ6e4J4AhP4hY/Gx+sO6dl9Y9pro88SpLj3SSbhj7b1oz4XqKVUswQLppqcKkd803s2XSnhrxOITuT1B6of4lx3qRKe22OpE+WLqweh/XVrD+VjYZPr5TAwAAADkBn5VqR/8AAA2AvAgAuolaIfmqm1hJ0iCoknMbEBnyAyCgnKp5TSHOV6Wpf0iXv9TKTwR4ccyTdswAAAA+QZuXSeEKUmUwIZ/+nhAAAEVFh6QAcm0KK9NMuQgBM8paQJwI7rv3NUrzngueAf4N9RAhW5UqtoDqv/1d3H0AAABXQZu7SeEOiZTAhn/+nhAAAEVFJZT8GIBmaHadINjiXnR+0qhTismpq6Gy7JVH011L+fgKMslabJt9mTgDtub25XH1acfjlZaIvPa0CLaDzoQKc14V6oMrAAAAO0Gf2UURPCP/AAAWwFoFgOX9xG9C9xtkJ21LfVeoMTnh8Yi+qiAy2QFUjr4UVMbKYN/znTYg7+3dGwUfAAAAIgGf+HRH/wAAI8M5bEd4dauJ1RIpNZxXWdc1eJNbg0wajukAAAAyAZ/6akf/AAAjvwQn2/7N1idiIA+x2LC/5RtwWLJvO9NAAPwrkYxrfvtmB6Z9vQRj44AAAABEQZv/SahBaJlMCGf//p4QAABFUQ4vBTca+16bh9YLJ5yWvP9+17gqBXEqwH8yO/hwwMbp2hOpQmsAGlS5XLaTPxePlTEAAABFQZ4dRREsI/8AABa7lD5e8OfcJ6P3Y6crmBr+QTiMs3gpUje3dMEIsjtMAC6gujf2sVXD20LDYzvHHazOXby2P2rUttsxAAAAKgGePHRH/wAAI8MXZCx3tSK11UPCCVvoog1+/rXsEiOjbbvbqYZcFejkgAAAADYBnj5qR/8AACO/Gm3MM157C6QZuPbjtpquVRiJGjQjYPCM/5QAmTPy713Qv72VHYCuuOXv23AAAABiQZojSahBbJlMCF///oywAABGAjRyAC/d5fW6FrcAU8rUOJjKQZ6cIbGLx3zUeG4FniOC59p7fMohH7CFwmViw9cZjZCrFBcGRRq3FjMqe51nYzc3pBR0uhRHFqDXqg28UfcAAABAQZ5BRRUsI/8AABbAWgIHK2fnA/faWtQAw7g7aceKhaA4chN1+tENnwANhvKg2TP1gKiSQwiOCg4o3cOiJbm/BgAAADEBnmB0R/8AACK39g73qr0yH7R97n91TccMDO9CUJpiXXi/fgAS/ufl0dOntmfEcduBAAAATwGeYmpH/wAAI8cynvkueFTwRG05bYAFnE30b3x1Y6IZLmXYaBQNVA/eUg4z3j35a76lZxbzYH+54FNdw/lWB8o3T9NsEv0oxQ7GzifY3gwAAABMQZpnSahBbJlMCF///oywAABGFEFWGR+wQFBP/b6aHgfsOjSVqI+S0PYZINJjuVLsF4egqEB4FPOZt0UZ/lYBQCjUCzVcCaenFmHFgQAAACxBnoVFFSwj/wAAFrMrtQW5HIHyD6jH2R1xoA4YxPLqDzIsUjNu2hJ/KC1bZwAAAE0BnqR0R/8AACOsORx+AFvErPdR6k1zIzgHFkw3rTJI+LTexxIO6wBVNYGfh1Ps6ISioUjKMpFZac4zCG98+M2/+KfEkCJyZjdk75z7ZwAAADQBnqZqR/8AACOyK2H4Abrl29x2R75pNsuCNWPUZsMorEx+jO6m6uUhDAFTXH9W3A2KD/BhAAAAdEGaq0moQWyZTAhf//6MsAAARnpvPcOkWABf7ajIJmRjcbvtckIIJfEDpPzLBUfn0vmUyZjL2YgCrX91mQtKAOmeXtGIn76lkcmweh9xRI6Vgcah/ANxinDlTn3RjXHyQHUTAr+jo1+chugF/RkTXBi6XSTcAAAASEGeyUUVLCP/AAAWu5xRlb+TC22oT4ipg+WKevONPgkNibOWap9tK51xb9ncKCnqlUq7+aTgEhrUrhuRpnsp+tJJcr2zuJ6W3AAAAFcBnuh0R/8AACPAuIaDOtHQA4LYGmzhQhC+Ihfa9RmFZ59ffPj9Fm5ldhbEUvvVuFFhmzhHS54TIREV5BYxsKLxjgHI/1Gtl4rhio8HQ9UqTAc6vcUOds0AAABXAZ7qakf/AAAjscENx2ivRYAAIetMlsMQzifvGsgRyb7nlcsUekqF1GXonb9fwxBDFct0rh8KdiJ04UZOTF0EbDuWz8VxTIVmzfgixZJOhcDqn/Z8XxeDAAAAWUGa7EmoQWyZTAhf//6MsAAARBRBXNXya/5+gPZoihjRO0r62s9mvzAu6isD1spjkv5TCYs1BE3sW+pEHVd/Kcl4IL8dW7xo9ecR2FCHliDJJucw8A6FCO9CAAAAPkGbD0nhClJlMCF//oywAABEAgX8xvm9ynoPdp2fiZ8FIoIARm3OqxZD/TaxtThxq/r+rEctLcc6Hxv/asGBAAAAV0GfLUU0TCP/AAAWMFoQZ4XQQAlpnXj/y/tTIwpFrgT9gAxTP2lhTLWdK7P2mqbh9vB4eH5v49RaIQDiDMNTy+VMpjlZ+GlKp14sHp0cwalgripxCU+FtwAAAEEBn05qR/8AACK9ln67sI7A/RQAWcTgBzjo/LozJGuM9mahaLHDH0TFvbNKCi3ZnkL4f9whCxV4ll/jwo36GVZSAwAAAElBm1JJqEFomUwIZ//+nhAAAENEanOn5fKByFcKjkkHK0UP0z12ACyFoVidY8ttnUjpTfhmCcNu0wNPnVwtx5phctURqrgrSfrCAAAAR0GfcEURLCP/AAAWMEaSExwiDDTOESbHe0gIrkAH1kF5SBzxJE5ZO1ipPRAIYf0bYMtvDNR0oCtlvSOx02WnVFJVEkAUAVGAAAAAOgGfkWpH/wAAIr2Wfruwjpiz3wAWQl4efX2x/xx7mWCYQRLA8NperpYsCfUhjDejKVtpaDI/ebXxck0AAABUQZuWSahBbJlMCGf//p4QAABDZAbY5EAZx11XFCqqzNy5BMhtGa2/st1QOtRNDE5UbzavElO0gI7BKmt8GfpDo7/9Xw4FkLfss0BWatJBvNXX86XwAAAASUGftEUVLCP/AAAWMDAnhAAunghCHWOpCzkpX+PLj3xUA0/BkVbj0XfG3UV6UYaw6ucIis0m5r5vD5fXmt0mA+01xI1kix4y8oAAAAA5AZ/TdEf/AAAiwLj6hQEWgAW8ASAZwvJ942AMTgcGUJnwARd33QGkz2RllMIdKi/am2W2RD50tfzBAAAASwGf1WpH/wAAIscLQKo4zTlvyAAEtRtXm90O60spdzmjt+MCxhns4Y5CBRWea9NSi3W+EDK0jhohBNwvEqPCSdid2Ryxk93Fp1smwAAAAFRBm9pJqEFsmUwIZ//+nhAAAENDlwPFphrdoiM0lmIUyMwuEbfe9AALpTUOsZgtwx8POYNJYcQskskhSLZronz5UWDh71+lv72iZSuFDzYAf4Fz3dcAAABJQZ/4RRUsI/8AABYinqi0PNMwkOUyZjJPOsZgY28g48A5ZkwEH189tnu26PzMmutmU1GYdpE/t2ripeGq/3o2W1Utwj3+xxbegQAAAEMBnhd0R/8AACGsQkV/CAAtRGVQhHEA8ydWL74bDE4cZPg6XKs7/0YekR8/Ryt8rQncct3Kpopa4c6NNH7w/k1Xw+9AAAAAOwGeGWpH/wAAIq4xL9F5PEboAFxrCJLQ/SZZbD0G/qMBQAGQFYjKsqg5SjpSKhDv7j8X3Oc1Qq7aq+k3AAAAZkGaHkmoQWyZTAhf//6MsAAARBROd+y4VLj6/Sl+mPaBvxABbwMI7Ax2B+7fjfwmw3MGCOOhElvuAUGRzqh69k/QRi79SLoVyapmal6SdsC0M61eK5KYVBj6wk4nhpl+jbjHn1lEMAAAAD1BnjxFFSwj/wAAFiKe3jcbRnjlBfKuQrrjNIvNbLycw2neenQH+1xFMxSUYAOTvnK2tvCfBz3Ao7lSPOmBAAAANAGeW3RH/wAAIaxCVOvwAturuHugehKhEoSugMB6pKKF5mQ2z43WEI/2SBHwqydX5hqMqq0AAABBAZ5dakf/AAAirjEv0XlFIKToDeGcAEqFUSo18QBXMnE/32FDOGy/GHHN+lw3jq7f/sHCSUq3i6kltb7fIe6g8EAAAABjQZpCSahBbJlMCF///oywAABEem8/3Gk2MAI96kjuYLS8nHpskEzsQngV3xYe1xV2cNDx+Y5pQgKkDcBSbPjT/OXmAKKrdGE3bzPdlb3zrAE2QlJ26U0hGxqHwti1wOd1vuewAAAAKEGeYEUVLCP/AAAWIp7eNxtHC/l0Ng8oFgZI48BsGI93UUxapZEs1vUAAAAiAZ6fdEf/AAAirBUOC8gZ6PMk+s6SEMT7qtoNP7BlxqMzwQAAACIBnoFqR/8AACKxwQ3H44sHHjGbdxd+TBpW8tBfKoAgGbghAAAAT0GahUmoQWyZTAhf//6MsAAAQhROeTV8krt/gV8ihG9UOuzQRYUSAAh8rR2ueDsckiuOdvAxDcEYmbMAcyZrpm79p2jB6zNfESyE6G3RO0AAAABBQZ6jRRUsI/8AABWSn02wiHQrpPCAyf6o46vXI7aAFSkwlz11+u+BU1pMIfZ8w/EJ8uErlH9VManvSNpfmL+dJsEAAAA5AZ7Eakf/AAAhrjL6/HB0CmwfAAuf3b6xVcUDsEY4q6qNpeFOu8FAe5W6zUg7mbYkVHrNznZvfkLBAAAAY0Gax0moQWyZTBRMM//+nhAAAEFEanSVS6uQAWlC7lDn3LtaH+5hmv6TuYBBfZY3zVGfsNRmODJqws4t9CWaZpu938nDxrP73GAl96s3ZsLNwSF+gOE4DFCgGMJ1NZ0DC5gTTwAAADsBnuZqR/8AACGuM0L+7dCTPaKAC4n9MJhv3LUkQe+AkdtUKTRCiJfPQUfUaRSV7Nx1sL5h+nFFqGsyoQAAAFZBmutJ4QpSZTAhf/6MsAAAQgD4YMAOket8AByu/PcyQ6+/3mrBhwbpuaIVX6EOPeAg/ZG6GX3sq4+ZPfqAt+QuhlmzRp0opXhzpQktdjo74Gzpd3bt7AAAADpBnwlFNEwj/wAAFZKe3jcbRwbjQSyuq0HWRpmyDtwv9sIkZKV3jNaHyUsyIxwPZIqBRrHgxN2XJaHbAAAAMwGfKHRH/wAAIanPZ2q1ZU9mmYYsRj0RftsHuyVnr0bG2ACcM+dOzZJxeEx+jak/HmshFQAAACwBnypqR/8AACGuMS/ReUPCfv+Wqawnx0rNMygBLC11nc8VX8TuH9wb8eBdxwAAAHFBmy5JqEFomUwIZ//+nhAAAEFEd8WQACq4P+WOjjjcGHJXIk8OKxhuXTK69CWDvv/9NpfZKxY8SkchVgVx1iTWpL/Xc7coAeLzHzv6nnKCKBdcvKpipXt0gDRlIUOmw1rcQNDFGgUlhyx9FkNP/RMQgAAAAClBn0xFESwj/wAAFZMrtQji+8fiSk3hv+fKSVyaEvaKPixkPO8iMSbuOQAAAC8Bn21qR/8AACG5wVHZTN8HlCxG4s42AED10Y7r5xEDTrxRNYpVd8rymfaHI1ryYQAAAD1Bm3JJqEFsmUwIZ//+nhAAAEFD1Ti4wzObzRT1ZCxK2WuifIiVzBUnK1oPZAq96bS5EGAG03C/qFJ5yFCHAAAANEGfkEUVLCP/AAAVkp7eNxtHC/l0iDe/8AQ7d33U7WdBbpPDeCRRdnyvLR0jC7l//ki5rXAAAAAmAZ+vdEf/AAAhwLjfwV6R2pnOmTkd2kjniEEpEDOqW6xFKBmu7kgAAAArAZ+xakf/AAAhrjEv0XlDs822QSHvPABwSvIra4CLWcLnW3e+doq6BBdO2QAAAFJBm7ZJqEFsmUwIZ//+nhAAAEG6bz28sUJY2SC6t11oewyduq6Wlb3Vckc/TqoP0LZ0WQACIigfjNxlqBAhwW6F/cDKR8/AZCfp3ics8CCZRcpgAAAAL0Gf1EUVLCP/AAAVlSX9TKsOQVj1Xt6N7o3+G6sCVBsUuEDbbT0afZjUVNYGwCHTAAAAKAGf83RH/wAAIawVDguyIH209OgoPC9R9KWiOaKkQAl1tZiNkdUD8mEAAAAvAZ/1akf/AAAgrjL6/RCM2OwIg/b+zwAsInADnHR+XSRKnleiemg1r/hoJyvH/ZgAAABeQZv6SahBbJlMCGf//p4QAAA/djnAQb8ft2mEUAAaDckyKuL4Q0oiHz5wPtYX12u14dCODo7YKjc4wsSmOXfivk4yB8Bb1hfk4twJoL11cmOCli6olHIO/gVhXKguYQAAAD9BnhhFFSwj/wAAFQKfCdEqn6K0BROjEZAAfzqWBLfySlQuijTFSIR9uGJTlIrLCzOVQCKA2VYQFCm1bdTNDH0AAAAlAZ43dEf/AAAgwLmhvBo6rIUdGki3+rBTQb75QRwgBM/QfVNWZgAAADIBnjlqR/8AACCuMeJ1oq+LPLPQAtWAYHeA6HuMq58zJcPOTibTZ+QQvKQyJQ+x2rTP0wAAAFxBmj5JqEFsmUwIZ//+nhAAAD9qcM2vY0AoQIBmg9aQN+TX3pSy+jFsIGMLaD8pBlX/5ADttdiAeyQmR8eFKejhzhfAFwP8qS7ljzwuSDLLHS8syqw661CXDGjHlwAAAC1BnlxFFSwj/wAAFQKfBgE0gaEUToAAupll7hQEY5CdLkqtmUjRiqmEh/B8BH0AAAAiAZ57dEf/AAAgn0772nBPb3ro3FK8dS6q4JVoh3cwdeaVYQAAACIBnn1qR/8AACCuMjaqdgxYwgtJjOha08G/ODFDOm8RVIWYAAAAbEGaYkmoQWyZTAhn//6eEAAAP15wzmnJ6cAgFtPxJsNJ+jGVCJ9hxUkGGZOIKwmrkUKGeCWb9ajNhwAPkCwlvxrdWtPTyfyM9j3s6gDfyTsn9BsgyYIWmnVPbvu4OFi+N563+Uu2VYZoRj+RsAAAACpBnoBFFSwj/wAAFQtfddP78cmkF0gGvHgzxFSEHd1SS1MlwykvGSu8s9MAAAAzAZ6/dEf/AAAgwLiE+/I8ZqIl6JN1ueJk1gAlim33tv/efo/qiITwTzd7zu7KlzezXHpgAAAAJAGeoWpH/wAAIL2WAooA+ycE7kb31/rZLqqce/zy9bDS9U55QQAAAFVBmqZJqEFsmUwIZ//+nhAAAD+8JzrOJB0jK+jNFrCuA8sbhOt00563RpZu6WSGmwf4MTddLdVNu66nkqsVd65MwFuHb4vxreGDZqIDB4W1vA39mFouAAAAK0GexEUVLCP/AAAVBSX9TKsOQ0v2pp42w5qrsCnBZrgiPmCYRUJtFdbKR6cAAAAqAZ7jdEf/AAAgwLjfwV6RZRRFZYjr8URXGAjwAC6GDqBPUMp6rUwIJg9NAAAAJwGe5WpH/wAAH7mn/7UuCnaLUZlT0VlDvcdFEksmpVQaVAikBrT1mwAAAERBmupJqEFsmUwIZ//+nhAAAD3+RIsAAug3c70FqNJe1JuojCt+8Eusl924Kmf/oWzRh+ICwBRErGcjTPYssZ9AJLmjCwAAAClBnwhFFSwj/wAAFHtfcMr1bAjHM4Mpc2O2rglKeofDl74EMLUMbEaMwAAAADABnyd0R/8AAB/Iyvfw9p3rPDTfAAtu91OxGXYQu+ryK8yrU7+QO2F9AXOrVvK65GAAAAAiAZ8pakf/AAAfxsBoo+KTjb/c61YrykxMDDv57eNW07uO6QAAAFJBmy5JqEFsmUwIZ//+nhAAAD3+dZDFABExtarKmRL24f5t6YRGw+/hi6EJf9xUwNd9zII8AC0sXtZFcrfRPqJiQ8v2SKto2FCO6wn6pIFTn0yZAAAAKEGfTEUVLCP/AAAUcp6otDzTwY+SKuqaNdSeZpD4RqFTqQRli5UxfaAAAAAmAZ9rdEf/AAAfyMpuEn16nRbZcoxGMkVdq/xQVwPe3sx8FN+/cs0AAAArAZ9takf/AAAfzjE/VRxml25QAlhKnHtiSSMCOjWGa5dV/wJaRS8J2flAGQAAAHZBm3JJqEFsmUwIZ//+nhAAAD4KcrCHgCdU2e/1VoRnC87duDv4E2GA6urKxiKF1Tb7wTjwCUi2NA074EhhenAMyw95sEU4nwrTDlNJxwVCuMPDtmOPOe9xwt48RAuALt+kpgL4Uc4KiYQMok4r3hXbEPLQ0TCZAAAAJkGfkEUVLCP/AAAUfmMoyIDI4Cngiw5nXRxBThummwcc51Jt95KQAAAAHwGfr3RH/wAAH8jKWRQrZNXZJ9nQMxbjJGL5Xs4t10gAAAAwAZ+xakf/AAAfuO2C+VTIuoDUnGDvIEw3JARJIVHkALcFIajMCRjBtJYYl5ohrEV7AAAAhkGbtkmoQWyZTAhn//6eEAAAPlwnOs4kHSNu8mADoYfcG0AklodvJ0yOvF+HpLkr2DTi/WoEf6mnBYCDgkK+O48b6sAqPI3adXgg5o27H29wMlR5r+l7N1TtSaTfTDjS9gOhDXwyqm8UHBUpx/1C+Pp/m8mkj8evfYpdHagGQuOTsqPTwzWfAAAANkGf1EUVLCP/AAAUdRfZyoRoQVtcpiGPRC3bUKspxmU4SjlwAg4Vtc50v+qrRx9Erzy3wQpbugAAADABn/N0R/8AAB+26Pagljd1YsHg/5p0+lppoASyljB68YBQUVtgFokd2Qw77nqOt3UAAAAtAZ/1akf/AAAfFsDLu3ncf/zC6J3xRIWUpKv43RIm1syHPTcU5PEDqTPX73dAAAAAa0Gb+kmoQWyZTAhn//6eEAAAPMi37v24tyRbl6kvp5AupNFq7vveMkwAdaUsAjs8Aj0iqNgbNSigLsgZiVPiBMPlvGA+frYf0gHUxgTKIFwY+t+QI0h9oe841Ha9mI0H83gkHHvY3sBFoX7dAAAAOkGeGEUVLCP/AAAT4p9NsIZn1L0AT//P58AewdXOYloMHKcAAakDWPU1pMDDixhq9R729utZAs4kcoEAAAAoAZ43dEf/AAAfBul7r6bpwon+nmEGZ50IatHmGHToc8Nmfxczuuq9owAAACwBnjlqR/8AAB8Jp/+1ETxXvC/Uq5VAYxvB1NhNrMAnzUnI1gLw0GHqJx1ggQAAAGVBmj5JqEFsmUwIZ//+nhAAADyecNdGzgKxZ4jI2Gtk8bWEEaFT5u7qoMcBSGSsAF11yBjxOagenryL//K3gv/+ydye4aFFqYzy6DO1YC0XsQ3hcCitNyBSqcy39WJWsNGbdFgzoAAAADlBnlxFFSwj/wAAE+KeqLQ809LKPU8O6hns3sZhQ9okJ5Mr0Kk2fpssogBKkAioncRH4f4WP0LV/SEAAABAAZ57dEf/AAAfGMpZFCtlKdRwvOZS4+P3rpj3m0DwbQ8CkQRIRNWC1zT9FUACcM9tVGXZmUDpT89dOin+T9FPSQAAAEABnn1qR/8AAB8Jpn9ReUOz2oR6e+1+wO/JuiqsDUgMrb2Em+npowRe0oAE4MBHVv8R+B5V7RwiYD4yUD6nWsMcAAAASUGaYkmoQWyZTAhf//6MsAAAPPyDM47QHVGoD+J1f8wn+J7KMANxDRs1DfrSSKthyVvHK02QOcSLWjsa59IsQ70664whvzwDQRMAAAA8QZ6ARRUsI/8AABPint5UhAA6A42w0AuwU7lJdI3VtXf6JSWbtzXntX/g0P7jZMgGQp9SxfllrG2tlFmhAAAAQAGev3RH/wAAHwbo8U9tKeKWX6ix17Ag0UZtrItddZp77kpcmadanuaUP3QAP3HhckFBXheGoIvXLbyk3vkSFmgAAAAqAZ6hakf/AAAfCacF4DyMs1su/B0wN9UNGyUhnMq7hAkN2Sb3wCMVUb0hAAAAbkGapkmoQWyZTAhf//6MsAAAPVwnP2vO4StcqkzssAITon2H64cFUCZ4+qi1jTBTA/bjnysaN8ydqCs+GrvpMpsBjdzVACDiXqinINTq1cU/daE7mbGF+7D+u4fd875tV/7hj70EsfIRLV3Ombs+AAAAN0GexEUVLCP/AAAT5SSh/aVTAFOHyjw9F5Jdk/HIlyiDYd4i7g7HQp4cb3tB8lQZ3cyNnA5O8oEAAAA+AZ7jdEf/AAAfCI4sTENIDm4AOkAhSK9uC6vEWwf1bkTjktkM0pY/j7fllGJ530Psu9EHay6oI8WQR480u9MAAAA1AZ7lakf/AAAeWaf1PVVZQAn3TXmCqkBp8Sqh52aMAXQPLQEmko0GACINNF3/uTWnO7yWg+UAAAB/QZrqSahBbJlMCF///oywAAA7nIMn00u6lvbjWTvcAzk+UP49CZYQbYrQIzdpZRBO2fpodhHdnafdkgV/WJ7M/UONHrHnbGm9p6gS2QvfWUtj6gBDpEUeQOLWG6hBWE2G1FAYwUHJ141LEXuCCXprHzGGnYvw2CcItiBTyCGS8QAAAE5BnwhFFSwj/wAAExzL2oI8sa+sUXACZXjZpqjzqFJQCSWjyKSrIaDJe6tDHFdhiDATUPPgRPygafebsDo3IDXkRdqAuhm3DGo1nrQtuPQAAAAyAZ8ndEf/AAAeTjTqfWWyFJvuzThOcRn77QQcjNqrvAS3/lXZshcKgjm4ylpiGvEbvSAAAAAtAZ8pakf/AAAeWaZ/Uc4htjHru7aXlsShRz/JuGPgVXs0RCdsJK0Omps2n0CpAAAAUEGbLEmoQWyZTBRML//+jLAAADunzMoFd01URoYAIfdmT6bQK0XWcLY7fmEyHxCg9Bqcg5zEXxmUmy/CA6eolC2+FpMCcd6uaPDQJuCXZkaIAAAAQwGfS2pH/wAAHlmmf1HOjTU8woPYEl5rnHIXlY2bVB7ZoUwwUxrAycgA/mL81yMzhb7cAQKYX6LjI3ccW8CGNRPs17QAAABjQZtQSeEKUmUwIX/+jLAAADv8J0U8WtazodAFaGEyEHZTS0IQZqbL8dgYpUKQ9Dtue4ViTcFp8XLjdF2T34PdqLXOdVUY+WD5iN6qZBfd9zghcb+f7MWJd4Yvkr/AW8E/01OBAAAASEGfbkU0TCP/AAATXSVB5W7N1j7cZkqO8bW+MJt3ZPtMkzzb3VN63KcEsZsO6h0rhvWBEsrUPhfaO/VAAXMkZQhjmLHv8Xi9oQAAADoBn410R/8AAB5omOT6sAkKgtI26RACyYOX9gUCpGvamvwo8Xb5VYfyafvF5BH6WAkxjgILBCrMlezBAAAAQAGfj2pH/wAAHlx66hVTsOnKNFPK2pcl5k5o4sHSRe3zuQhm/MtvB4o5KWZQAHvxfbsnYl9fJzMrhSO+EYE3XswAAABmQZuSSahBaJlMFPC//oywAAA6SxNfWcALD6lCaNcKCoKXjLgA0vZ90M0mAxjpfNNRpLk/UFVgLCoW2cHnKBJr057sads6LZx9CwnN0ika2dJfwQqGWjaFY+AR1FN5ccnD4orH+eJsAAAASAGfsWpH/wAAHamn9lZ0vgluHexxxKqyr0AY1Y8L5VU26xrWceLx0cu3KgJdKm6AC0PwByu1MuCyo+mWuSb7fUlEeu3A7NM75wAAAEZBm7RJ4QpSZTBSwz/+nhAAADneQ8ZvQQLIL73zSiOQ1CT/+wh+8mfJXhST+g+fngjfL+fd1asd9j5J1Lv/tyklsJ6IlmjWAAAAPwGf02pH/wAAHbZjbEMV9eSfCMNCNRyC/2MfguHX8Isw68+mQzISSMdXHraaAAe1ofdG35C82U9oPhn00xQgzQAAAENBm9hJ4Q6JlMCGf/6eEAAAOd6LLxtvGvcqQpPMwikZRrGkinz+4qUnZBbosYsPf/Dg5wvvWik904L60/7IJNTJKGyxAAAAPkGf9kUVPCP/AAAS1b477OIRQDlz8NPs9MChlnZxYdgF4fyx0tNSd4gUeo7yVXcRCM2JkBGVUdBQllCo/jXQAAAATAGeFXRH/wAAHbhJ5qSAFYudWyodRFHAjwM7C0Lj0FusKnjq5uojxC7YfbO4W5J4R3jHS9R+tRWzky5DV2XxHltxxiVjkivcgWH2G0cAAABUAZ4Xakf/AAAdqaZ/UQKgTmHSO6I2AAtv3b6xIF1XdS0ZgXWdUI6aACFb7WlGfEBuOq0gAXcOcHlPZXgtGTFl1QFqi5d4QnjBtulGomd24ICESu/xAAAAb0GaHEmoQWiZTAhf//6MsAAAOpwnPdKdFgAOPbUTPkc0dBbbukQI0iBgHkekYbuxQzIsP7VF3tyPS+qC7wrkT+DPuQ9DOop+Q8j+T82axb0XS0cfYmYkb2OcUbC9aP1IPckyNBZ2VxfgpQsJpVSnIAAAADpBnjpFESwj/wAAEtf+ZhpwBaQAKB0VdbeZAupNQ+uPUQXG1tAMNbWOz+NXyeWJ6nsb6XRkjuqDlr7hAAAANQGeWXRH/wAAHbgs/y8T9FPCJ+Q80HnP9FCQ+vQIiD524IvZbnaspI+kqfA5/iqaI1UGyFHAAAAAQAGeW2pH/wAAHQZjjF51LktcqgET7BMllVfAEV1gTYJwsPvHoUWU93kr28utoeEoXIB3mZoAE4msumbto4xNL/EAAABkQZpfSahBbJlMCGf//p4QAAA4fn/xm9DDCjjF0AGwtNsc0l/wl9jZHrE0iVv4lqTZtIhqutVMetbovCxvowjEOuKa/QBYcRgQ8p7oaQ92gwTSo2e6IwgIoMu2AHCdAwTmN4uDwQAAAFNBnn1FFSwj/wAAEmI5t7AQxUADt+fVZrvxt1YQnXei0UiTq6XhW5+2Bq2VSCm1a4uw2e/LK50Up3J9L/AYEV/UGqeEkIdjB1u7pLEz5KeKz5riDgAAAD8Bnp5qR/8AAB0GYybmQ67Q1Kx4pcHG9Esu2YNh6SOmCKABxIxPCV6matin6t5/Gfaa2bVDOgdaF+1I3GdKqJgAAABiQZqDSahBbJlMCGf//p4QAAA43Cc/uKj7Cxw1IkIz0hyVxzIADn4r0ZhbZS8nUMLlfratnlqA2sU5HdA8Ci3DlkRbcgkhEpLqKaEx5mKTRzhej9u5O9RCcCxAlZ+Ejj6LQs8AAABOQZ6hRRUsI/8AABJiPM14j7RoCyDvda+9JOTMoyPiawB9/ubmwje5DueEXJwDkHxSYJOXjK4aWUItxidfYiMRJUPxFvECt8DHggia3ghUAAAASAGewHRH/wAAHQgs/y8T1EoZx8uPP9LORbVq9xGzsDzyfFFtZfxPRyrJmI73QATH44Ac4BPy163lZrBVTN/pMUken7JZ98oAgQAAAEIBnsJqR/8AABz47Ta9GtUn6Qul36fiuisIcFHmCTZxxZVBIUIgmaTK0JYOmGpgA1Gd/xI9X3tqqZYb0F9B5oqTCFQAAABxQZrHSahBbJlMCGf//p4QAAA3K9DnqAIrG+1rXF+JCfpl3gll1MDahwH2nzSjD1wmDIzvGykaUOxovX1rChnOn+TV67be4Id01W+471Ym5fya9/2JmV/K/SNP/AjOX+FJq264vP4AMa9GEx+cmzhN2MkAAABCQZ7lRRUsI/8AABHdNpWQ7VVT7otZ5iASD+Uu/ZP/F2mrepbDr6oPFFiRQkGjK70G+Ie+ZJu+CAFvg2EI1EDWlcgDAAAANwGfBHRH/wAAHFgtVKbfHPJkx77t9pZPV4lceUbu1+jJRN0yqsSwyEPkJL7FjKAT58ZqcwxLwcEAAAAxAZ8Gakf/AAAb9OK0E3VcgIrhcV6zGYGRsS1RQ7/K2KN0WauaKuMLO9XlC10p/nX4OQAAAFxBmwtJqEFsmUwIZ//+nhAAADcr2l+6yMGNVs7gw3HwJJkAWjh9CTIsoOFxOzdE6YhH8xgAjhhTw3IngTECt3g+A4JjN/NqlzvO01DRftU6AnI0xPem9YugujcoKwAAADdBnylFFSwj/wAAEdXgy/8fC+8+7JbVeg05Ldd00+y8yOQ71Jrtu4sFSYghwjOvlkBo7VJYjFgzAAAAPgGfSHRH/wAAHFgsoqStqpW8JukMk8//Ql9k364IRaAIX3Pq1FQpPyYBe55zX2My4AHo2UnO/W3uBte6Wnw/AAAANAGfSmpH/wAAHEjtNr0qNPqBKGq9eMVAAPiEk3+enVwquDdj+kIVC+rS+lBTv2nU0gptsCwAAAB3QZtPSahBbJlMCGf//p4QAAA3fCc61Dd6n5FWgMFSCMfmL2ew79eWdRU1gj3s5D18fhBuw7GqsyMfjNvVWWGFi9nkM9U4snBbpzGVgnxVEJ9WyrpD1VvZ29PyGvpRIw8Xiobf5+Vzh2FwiDn3Yd6RFFhqASfxbkAAAAAzQZ9tRRUsI/8AABHX8RIQSDZ67AE5Kjeu0Y9TZi/7ZYm4ahXZS30l7Cd1MsXzonzpGS+lAAAAQgGfjHRH/wAAHEiNjcYBS8bvUpe8VKWQZGSSOPfKJzD2mGQLwLkddAA2GDnSgpzuzMoTpCqzUTzkDd1p3y7xFmVgsQAAADcBn45qR/8AABucX9ofYBDnrlE8Cyz1+SvdhIIzFcS0h46ac/YXlVzUWUdM0SJwt75BHEtwEV4fAAAAg0Gbk0moQWyZTAhn//6eEAAANfPqHjc9BABIA+ABw3oxbTWEY3Ri3EL5cZ7EtkPz2WxH8pYzYL+WW4nuevgp13P+nVp+4z6Ag98PdrHAs51bp5F0UMGABg/ixIDLhIkmbtIqpspkeKrDbozPFD2pdCQ4YJM1iLs7rK0z6i6zO4upPEEIAAAAPEGfsUUVLCP/AAARXTaUI9mRZx+W7xiVZuVEfge76A3PfDbftpDtu0r96BC55o9D3UkAH5nDdWTEIqEPSAAAAEIBn9B0R/8AABupbbykpq43ap7ICmxizdOFatiiGOoYjs52AD78GeDLPZg9dcUbqbfZLieGlJH08w+JeSvZIbJ8pnEAAAA1AZ/Sakf/AAAbp9p6sSdejr8cIlTpwWzEz/XPvUVDtds7omnwYF7cgvY9ozj3AgSLHPOmavkAAACCQZvXSahBbJlMCF///oywAAA2nrZ+1iMGAHQLPtRFN3b5fLj9kCgkfxL64e401uqfW8CwUiDM1mDYB1I+vvRgGXGRWXLXbRJRJxVTEvgM+F9/5l6Dm2kucL/MxtzYTuKWDQtgfoOsgQt9nBYwfHLWavFgIXsXw0QiWrpYSI0j0oA+uAAAADxBn/VFFSwj/wAAEVgFn1uIoB5mImGA1805/iM6FvMYz8XzpFfpcdf2uqEbxXivSSTB804BLNafbvEQZi8AAABNAZ4UdEf/AAAbm/6xRhEpy8wEUTB/y/h9xcRXJZO4x+vmSGz5Tl6jpe6ABsNl1uJxFJ8QGkoORnzWymp9Oq/qa6oBxodwGq78u+8sKi4AAABMAZ4Wakf/AAAbB9p/J43sIfBdFZs9V8rAUrlxrGCr0GYmbOmY2umzhUa7t+FWKj3oGGm9eHAEYgCRxCKOXtyVjl7/lq729/H/Gs3/qwAAAGBBmhtJqEFsmUwIX//+jLAAADVcJz3VTlXptA97va+w9GD0CPg2/1m+3w1KEVTkfeqTUkHXYfGSZy56AGuig0JmtT4QPQdEh5Tpn8yoUo753kPUZcaBSDa0BBU0kyrurxEAAABEQZ45RRUsI/8AABDiPtvfWvea9kBWPKQDFb0Z4Nd9/yagAIyDTJ8g4QSg2lupJiyERcMP0Oq4ptwSv8QrAm8at1Ixn8QAAABSAZ5YdEf/AAAbCW28pHIB1NO8NcHE0T/bWjTXnbGl7SmRUVzyPIFmtVUt/+ACcM9tVGXZmUC4IHRjjuwVPBqTMlvVJTDxYZSYuUS1P0fGOlqcQQAAAEABnlpqR/8AABsH3zK+AD9hZEu8UFmuYn/rFOSHaUin/K8nXAQJOynSUBVDazwRN8PMNID+tKo80jtOFP+3O+YGAAAAb0GaX0moQWyZTAhf//6MsAAAM9SDxz4oJ6PaKw9f4YNnKKMzsIQIS6gd5sB7fKEk74QEmJJGH+wZgQe/cW4cIDIl9/xd6z3d3nBFC4mFxHFRri3QM5+e5e5UZxISKrGyfP5FFWmpeF+hEIkv6seWgQAAAFBBnn1FFSwj/wAAEByiy/IFjiIAJ7Ftm06WX6UZ9Psje7P8VlNqnVQm5q4U0id3aiI+YsbxTIKiWYacHa5+ApmGaURd+2ycqYXPISUcPwxpgQAAAEIBnpx0R/8AABpjZS+VfvrTWi2dzs2KffAP0m0ZrXUQ7vQ0LtCD6kliDtGpET3cqABtFKJ5VlQd6HRIoUVVxdU9kOAAAAA0AZ6eakf/AAAaXF9j9I27POnU6rk7w3AyJbEkWWPPLLgBZr+ngdghM//WPPaqMMa0XmslIAAAAHVBmoNJqEFsmUwIV//+OEAAAMnv/OLieH1UDNl+/5N6e5gT/MBKQVqi95OFVBKqik2YIQbLff/VjLs9EAQzo7vI6LpSSt3eBggDHkXES1pQtOz1NDiEwfDqAsNwDdzb3Ox+I210AmE1cVqdzd+owBhmCxkDOaEAAABJQZ6hRRUsI/8AABBYBZ/l2js7QgCnywq41WEdIUwSRBwhisz/MMsLUVek/amaZyrq2o77/8LfEY3X64sDUEgcBvn3sUo1QxGGgAAAAD4BnsB0R/8AABpjaLmQGFM27N8OOXEER2x19mjN6P3xQZnFvvv22X99uLzSZAA1Gc/f0T+2t2XSrdjIwCLJHwAAAEABnsJqR/8AABnOmkuISGBjmFeumlA/nlPRh0olNXikCU5u+YVVuWEk5xPuHOv9HM/to4pAA+6p/Uy7mbEvxcx4AAAAUkGaxUmoQWyZTBRMK//+OEAAAMOd/2foJm5QRq0fWVzuBPgN/9pa3/iK9v/vpi50LKLccShL3dPGFiAECFwUCzNv67PUsGSqjAMO7KUG9dbUQVkAAAA9AZ7kakf/AAAZsKhYmUhqCzHdtQMF+bdjS2TNfgvf/V6Nv7Ktd254orIieNZz0rcsWhhxIQWmfVt91NzZcQAAAFtBmudJ4QpSZTBSwj/94QAAAwL/v+vgJt863Y9qOS+6Ao/MxmelgHAGENjDYrSApBgPb3rXptgzeOkgATI9GPTYVV62Xt2FUGRB52mX71xwJ8uR64BXKQ9USjVxAAAALgGfBmpH/wAAGcd7NLN1axEJaPxz9xHBN/2Dd4cQgQh5qh+ZKtUW5AiL1Z7G5I8AAABLQZsISeEOiZTAj//8hAAAC1Iqq23rXjAtaML5I1SNVX+QaA6cQooMA3sAOHgQhGVBABEG5DHy+cQ61DgOdHqxrzzXKxibw+ml32+WAAAMV21vb3YAAABsbXZoZAAAAAAAAAAAAAAAAAAAA+gAAA+0AAEAAAEAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAuBdHJhawAAAFx0a2hkAAAAAwAAAAAAAAAAAAAAAQAAAAAAAA+0AAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAQAAAAAJYAAABkAAAAAAAJGVkdHMAAAAcZWxzdAAAAAAAAAABAAAPtAAAAgAAAQAAAAAK+W1kaWEAAAAgbWRoZAAAAAAAAAAAAAAAAAAAMgAAAMkAVcQAAAAAAC1oZGxyAAAAAAAAAAB2aWRlAAAAAAAAAAAAAAAAVmlkZW9IYW5kbGVyAAAACqRtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAApkc3RibAAAAJhzdHNkAAAAAAAAAAEAAACIYXZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAJYAZAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAADJhdmNDAWQAH//hABlnZAAfrNlAmDPl4QAAAwABAAADAGQPGDGWAQAGaOvjyyLAAAAAGHN0dHMAAAAAAAAAAQAAAMkAAAEAAAAAFHN0c3MAAAAAAAAAAQAAAAEAAAYwY3R0cwAAAAAAAADEAAAAAQAAAgAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAIAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAIAAAAAAQAABAAAAAACAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAQAAAAAAgAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAEAAAAAAIAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAAAwAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABAAAAAACAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAUAAAAAAQAAAgAAAAABAAAAAAAAAAEAAAEAAAAAAQAABQAAAAABAAACAAAAAAEAAAAAAAAAAQAAAQAAAAABAAAFAAAAAAEAAAIAAAAAAQAAAAAAAAABAAABAAAAAAEAAAMAAAAAAQAAAQAAAAABAAADAAAAAAEAAAEAAAAAAQAAAgAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAMkAAAABAAADOHN0c3oAAAAAAAAAAAAAAMkAAARZAAAAsAAAAFoAAAA3AAAAOAAAAKUAAABEAAAALQAAACcAAACeAAAAQwAAAC0AAAAoAAAAQgAAAEAAAAA0AAAAMAAAAIYAAABKAAAAIwAAADgAAABwAAAAPQAAAEIAAABbAAAAPwAAACYAAAA2AAAASAAAAEkAAAAuAAAAOgAAAGYAAABEAAAANQAAAFMAAABQAAAAMAAAAFEAAAA4AAAAeAAAAEwAAABbAAAAWwAAAF0AAABCAAAAWwAAAEUAAABNAAAASwAAAD4AAABYAAAATQAAAD0AAABPAAAAWAAAAE0AAABHAAAAPwAAAGoAAABBAAAAOAAAAEUAAABnAAAALAAAACYAAAAmAAAAUwAAAEUAAAA9AAAAZwAAAD8AAABaAAAAPgAAADcAAAAwAAAAdQAAAC0AAAAzAAAAQQAAADgAAAAqAAAALwAAAFYAAAAzAAAALAAAADMAAABiAAAAQwAAACkAAAA2AAAAYAAAADEAAAAmAAAAJgAAAHAAAAAuAAAANwAAACgAAABZAAAALwAAAC4AAAArAAAASAAAAC0AAAA0AAAAJgAAAFYAAAAsAAAAKgAAAC8AAAB6AAAAKgAAACMAAAA0AAAAigAAADoAAAA0AAAAMQAAAG8AAAA+AAAALAAAADAAAABpAAAAPQAAAEQAAABEAAAATQAAAEAAAABEAAAALgAAAHIAAAA7AAAAQgAAADkAAACDAAAAUgAAADYAAAAxAAAAVAAAAEcAAABnAAAATAAAAD4AAABEAAAAagAAAEwAAABKAAAAQwAAAEcAAABCAAAAUAAAAFgAAABzAAAAPgAAADkAAABEAAAAaAAAAFcAAABDAAAAZgAAAFIAAABMAAAARgAAAHUAAABGAAAAOwAAADUAAABgAAAAOwAAAEIAAAA4AAAAewAAADcAAABGAAAAOwAAAIcAAABAAAAARgAAADkAAACGAAAAQAAAAFEAAABQAAAAZAAAAEgAAABWAAAARAAAAHMAAABUAAAARgAAADgAAAB5AAAATQAAAEIAAABEAAAAVgAAAEEAAABfAAAAMgAAAE8AAAAUc3RjbwAAAAAAAAABAAAAMAAAAGJ1ZHRhAAAAWm1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALWlsc3QAAAAlqXRvbwAAAB1kYXRhAAAAAQAAAABMYXZmNTcuODMuMTAw\" type=\"video/mp4\" />\n",
+       "              </video>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "mp4list = glob.glob('video/*.mp4')\n",
+    "\n",
+    "if len(mp4list) > 0:\n",
+    "    mp4 = mp4list[0]\n",
+    "    video = io.open(mp4, 'r+b').read()\n",
+    "    encoded = base64.b64encode(video)\n",
+    "    ipythondisplay.display(HTML(data='''<video alt=\"test\" autoplay \n",
+    "                loop controls style=\"height: 400px;\">\n",
+    "                <source src=\"data:video/mp4;base64,{0}\" type=\"video/mp4\" />\n",
+    "              </video>'''.format(encoded.decode('ascii'))))\n",
+    "else: \n",
+    "    print(\"Could not find video\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OpqXiZUsznkY"
+   },
+   "source": [
+    "That's it! We have successfully solved the Cartpole problem!"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "name": "reinforcement_learning.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
The diff is a little hard to review. This PR would unblock the `submodule` workflow in website repo.

To verify this PR,

1. open a new env with GitHub Codespaces.
2. Run `pip install nbformat`
3. Run `jupyter nbconvert --to markdown 'how-to-guides/*.ipynb' --output-dir output --NbConvertApp.output_files_dir $(pwd)/static/_images/`
4. Similar command for tutorials as well
5. `nbconvert` can successfully convert notebook to markdown