### PR TITLE
Add setup_tb_logging example to getting started tutorial

### DIFF
--- a/tutorials/beginner/01-getting-started.ipynb
+++ b/tutorials/beginner/01-getting-started.ipynb
@@ -106,7 +106,7 @@
     "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
     "from ignite.metrics import Accuracy, Loss\n",
     "from ignite.handlers import ModelCheckpoint\n",
-    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
+    "from ignite.handlers import TensorboardLogger, global_step_from_engine\n",
     "from ignite.handlers.logger_utils import setup_tb_logging"
    ]
   },
@@ -684,7 +684,7 @@
     "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
     "from ignite.metrics import Accuracy, Loss\n",
     "from ignite.handlers import ModelCheckpoint\n",
-    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
+    "from ignite.handlers import TensorboardLogger, global_step_from_engine\n",
     "from ignite.handlers.logger_utils import setup_tb_logging\n",
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",

--- a/tutorials/beginner/01-getting-started.ipynb
+++ b/tutorials/beginner/01-getting-started.ipynb
@@ -106,7 +106,8 @@
     "from ignite.engine import Engine, Events, create_supervised_trainer, create_supervised_evaluator\n",
     "from ignite.metrics import Accuracy, Loss\n",
     "from ignite.handlers import ModelCheckpoint\n",
-    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine"
+    "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
+    "from ignite.handlers.logger_utils import setup_tb_logging"
    ]
   },
   {
@@ -488,6 +489,33 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c5ed1d7d2add4b3b",
+   "metadata": {},
+   "source": [
+    "If you prefer a simpler setup, Ignite also provides\n",
+    "[`setup_tb_logging()`](https://docs.pytorch.org/ignite/master/_modules/ignite/contrib/engines/common.html#setup_tb_logging)\n",
+    "as a helper that configures a `TensorboardLogger` for you. It automatically attaches common logging events such as\n",
+    "training metrics, optimizer learning rate, and evaluator metrics:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c7b286768354b2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tb_logger = setup_tb_logging(\n",
+    "    output_path=\"tb-logger\",\n",
+    "    trainer=trainer,\n",
+    "    optimizers=optimizer,\n",
+    "    evaluators={\"training\": train_evaluator, \"validation\": val_evaluator},\n",
+    "    log_every_iters=log_interval,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "Aq0qwiZrEcF_",
    "metadata": {
     "id": "Aq0qwiZrEcF_"
@@ -657,6 +685,7 @@
     "from ignite.metrics import Accuracy, Loss\n",
     "from ignite.handlers import ModelCheckpoint\n",
     "from ignite.contrib.handlers import TensorboardLogger, global_step_from_engine\n",
+    "from ignite.handlers.logger_utils import setup_tb_logging\n",
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
     "\n",
@@ -753,6 +782,15 @@
     "        metric_names=\"all\",\n",
     "        global_step_transform=global_step_from_engine(trainer),\n",
     "    )\n",
+    "\n",
+    "# Alternatively, setup_tb_logging can be used to configure the same TensorBoard logging setup.\n",
+    "# tb_logger = setup_tb_logging(\n",
+    "#     output_path=\"tb-logger\",\n",
+    "#     trainer=trainer,\n",
+    "#     optimizers=optimizer,\n",
+    "#     evaluators={\"training\": train_evaluator, \"validation\": val_evaluator},\n",
+    "#     log_every_iters=log_interval,\n",
+    "# )\n",
     "\n",
     "trainer.run(train_loader, max_epochs=5)\n",
     "\n",


### PR DESCRIPTION
Summary
- add `setup_tb_logging` import to the Getting Started tutorial
- include a minimal helper-based TensorBoard logging example as an alternative to manual logger attachment
- explain that the helper automatically attaches common logging events such as training metrics, learning rate, and evaluator metrics
- mirror the helper-based option in the complete code section as a commented alternative

Notes
- this updates the source notebook in `pytorch-ignite/examples`:
  `tutorials/beginner/01-getting-started.ipynb`
- the docs site markdown in `pytorch-ignite.ai` is generated from this notebook, so updating the notebook is the correct source change
